### PR TITLE
feat(vendors): 新增「ChatGPT / Codex（订阅）」厂商，用 ChatGPT 订阅驱动 Chat 模式

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -192,6 +192,7 @@ import {
 } from "./skills/music-companion-host";
 import { initGameBot } from "./game-bot";
 import { initChannels, shutdownChannels, setChannelsConversationLifecycle } from "./channels/init";
+import { bootstrapCodexOAuth, type CodexOAuthBootstrap } from "./orchestrator/vendors/codex-oauth-bootstrap";
 import { buildChannelAttachmentInputs } from "./channels/agent-input";
 import { setDispatcherBuildAndRunAgent, setDispatcherSynthesizeTts, setDispatcherBroadcastChat, setDispatcherLoadGeneralSettings, setDispatcherLoadRecentHistory } from "./channels/dispatcher";
 import { createWindowLifecycleTracker } from "./electron-window-lifecycle";
@@ -263,6 +264,8 @@ let callWindow: BrowserWindow | null = null;
 let schedulerEngine: SchedulerEngine | null = null;
 let screenshotService: ScreenshotService | null = null;
 let proactiveChatService: ProactiveChatService | null = null;
+/** ChatGPT / Codex（订阅）桥 + OAuth 的句柄；退出时要关掉监听。 */
+let codexOAuthBootstrap: CodexOAuthBootstrap | null = null;
 let normalConversationBusyCount = 0;
 let proactiveScreenLocked = false;
 const live2dWindowLifecycle = createWindowLifecycleTracker<BrowserWindow>("live2d-main", {
@@ -5364,6 +5367,22 @@ app.whenReady().then(async () => {
 
   void initChannels();
 
+  // ChatGPT / Codex（订阅）：本地桥 + OAuth 会话管理 + 登录用的 IPC。
+  // 桥起来不代表已登录——未登录时对 /v1/chat/completions 的请求会收到清楚的 401，
+  // 引导用户去设置里点「登录 ChatGPT」。桥起不来不该拖垮整个 app。
+  void bootstrapCodexOAuth()
+    .then(bootstrap => {
+      codexOAuthBootstrap = bootstrap;
+      logger.info(
+        LogTag.CodexOAuth,
+        `桥已启动。设置 → 模型设置里选「ChatGPT / Codex（订阅）」，点击「登录 ChatGPT」` +
+          `完成授权后会自动填好 Base URL / API Key。`,
+      );
+    })
+    .catch(err => {
+      logger.warn(LogTag.CodexOAuth, "启动失败（其它厂商不受影响）:", err);
+    });
+
   // 任务清单（todo_write 工具的持久化 + 事件广播）：
   // - loadTodos 从磁盘恢复上次未完成的任务（跨重启延续）
   // - onTodosChange 按 mode 订阅变化，把 TodoState 作为 CUSTOM 事件转发给所有聊天窗口
@@ -5705,6 +5724,7 @@ app.on("before-quit", () => {
   flushTokenUsage();
   void shutdownChannels();
   void screenshotService?.shutdown();
+  void codexOAuthBootstrap?.dispose();
 });
 
 app.on("activate", () => {

--- a/src/main/orchestrator/vendors/capabilities.ts
+++ b/src/main/orchestrator/vendors/capabilities.ts
@@ -115,6 +115,27 @@ export const PROVIDER_CAPABILITIES = [
     supportsVision: false,
   },
   {
+    id: "codex",
+    displayName: "ChatGPT / Codex（订阅）",
+    // baseUrl 是占位：真实端口由 codex-bridge 启动时随机分配，桥的 baseUrl/token
+    // 登录成功后由设置面板自动填入（见 codex-oauth-ipc.ts 的 CODEX_OAUTH_GET_STATUS）。
+    transport: "openai",
+    baseUrl: "http://127.0.0.1:0/v1",
+    authStyle: "bearer",
+    // 只能填 Codex 后端 /models 列出的 slug。用 API 那边的名字（gpt-5.1-codex 之类）
+    // 会被回 400 "not supported when using Codex with a ChatGPT account"。
+    defaultModel: "gpt-5.6-sol",
+    // 只支持 Chat：Work 模式的 tools 会被桥以 400 拦掉（见 codex-bridge.ts 文件头）。
+    // 注意 supportsTools 全仓库没有读取点，这里标 false 只是声明意图，拦截靠桥本身。
+    supportsTools: false,
+    supportsThinking: false,
+    thinkingField: null,
+    cacheStrategy: "none",
+    testStrategy: "text",
+    // 桥把消息压成纯文本 input_text/output_text，图片走不过去。
+    supportsVision: false,
+  },
+  {
     id: "claude",
     displayName: "Claude（Anthropic）",
     transport: "anthropic",

--- a/src/main/orchestrator/vendors/codex-bridge.test.ts
+++ b/src/main/orchestrator/vendors/codex-bridge.test.ts
@@ -1,0 +1,387 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startCodexBridge, type CodexBridgeHandle } from "./codex-bridge";
+import type { CodexOAuthAuth } from "./codex-oauth-auth";
+import { OpenAICompatAdapter } from "./openai-adapter";
+import { getCapability } from "./capabilities";
+
+function fakeAuth(overrides: Partial<{
+  loggedIn: boolean;
+  accessToken: string;
+  accountId: string;
+  getValidAccessTokenImpl: () => Promise<{ accessToken: string; accountId: string }>;
+}> = {}): CodexOAuthAuth {
+  const loggedIn = overrides.loggedIn ?? true;
+  const accessToken = overrides.accessToken ?? "test-access-token";
+  const accountId = overrides.accountId ?? "acct_test";
+  return {
+    getStatus: vi.fn().mockResolvedValue(loggedIn ? { loggedIn: true, accountId } : { loggedIn: false }),
+    getValidAccessToken:
+      overrides.getValidAccessTokenImpl ?? vi.fn().mockResolvedValue({ accessToken, accountId }),
+    forceRefresh: vi.fn().mockResolvedValue({ accessToken, accountId }),
+  } as unknown as CodexOAuthAuth;
+}
+
+function sseCompletedResponse(text: string, usage: { input_tokens: number; output_tokens: number }): Response {
+  const payload = {
+    type: "response.completed",
+    response: {
+      status: "completed",
+      output: [{ id: "msg_1", type: "message", content: [{ type: "output_text", text }] }],
+      usage,
+    },
+  };
+  const body = `event: response.completed\ndata: ${JSON.stringify(payload)}\n\n`;
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+/**
+ * 真实抓到的 gpt-5.6-sol 响应形状（2026-07 实测）：终结事件的 output 是**空数组**，
+ * 正文只出现在中途的 output_text.delta 和 output_item.done 里。
+ * 之前的实现只读终结事件的 output，于是拿到空字符串、误报 502。
+ */
+function sseRealWorldShape(text: string, usage: { input_tokens: number; output_tokens: number }): Response {
+  const ev = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+  const body =
+    ev("response.created", { type: "response.created", response: { status: "in_progress" } }) +
+    ev("response.output_item.added", {
+      type: "response.output_item.added",
+      item: { id: "msg_1", type: "message", content: [] },
+    }) +
+    ev("response.output_text.delta", { type: "response.output_text.delta", delta: text }) +
+    ev("response.output_item.done", {
+      type: "response.output_item.done",
+      item: { id: "msg_1", type: "message", content: [{ type: "output_text", text }] },
+    }) +
+    // 注意这里 output: [] —— 这就是真实响应，不是造出来的极端情况
+    ev("response.completed", {
+      type: "response.completed",
+      response: { status: "completed", output: [], usage },
+    });
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+async function postChatCompletions(
+  bridge: CodexBridgeHandle,
+  body: unknown,
+  token = bridge.token,
+): Promise<{ status: number; json: any }> {
+  const res = await fetch(`${bridge.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => undefined);
+  return { status: res.status, json };
+}
+
+describe("codex-bridge", () => {
+  let bridge: CodexBridgeHandle | undefined;
+
+  afterEach(async () => {
+    if (bridge) {
+      await bridge.close();
+      bridge = undefined;
+    }
+  });
+
+  /** 不该被打到上游的用例（400/401 那些）统一用这个：被调用就是 bug。 */
+  const noUpstream = (): never => {
+    throw new Error("这个用例不应该发起上游 Codex 请求");
+  };
+
+  it("401 当 bridge token 不对", async () => {
+    bridge = await startCodexBridge(fakeAuth(), noUpstream);
+    const { status, json } = await postChatCompletions(
+      bridge,
+      { model: "gpt-5.1-codex", messages: [{ role: "user", content: "hi" }] },
+      "wrong-token",
+    );
+    expect(status).toBe(401);
+    expect(json.error.message).toMatch(/token 不匹配/);
+  });
+
+  it("400 当请求带 tools（Work 模式硬拦）", async () => {
+    bridge = await startCodexBridge(fakeAuth(), noUpstream);
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+      tools: [{ type: "function", function: { name: "foo", description: "", parameters: {} } }],
+    });
+    expect(status).toBe(400);
+    expect(json.error.message).toMatch(/只支持 Chat 模式/);
+  });
+
+  it("400 当请求带 tool_choice", async () => {
+    bridge = await startCodexBridge(fakeAuth(), noUpstream);
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+      tool_choice: "auto",
+    });
+    expect(status).toBe(400);
+    expect(json.error.message).toMatch(/tool_choice/);
+  });
+
+  it("400 当请求 stream: true", async () => {
+    bridge = await startCodexBridge(fakeAuth(), noUpstream);
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+    expect(status).toBe(400);
+    expect(json.error.message).toMatch(/流式/);
+  });
+
+  it("401 当未登录", async () => {
+    bridge = await startCodexBridge(fakeAuth({ loggedIn: false }), noUpstream);
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(401);
+    expect(json.error.message).toMatch(/登录 ChatGPT/);
+  });
+
+  it("happy path：响应能被真实 OpenAICompatAdapter.parseResponse 解析", async () => {
+    const codexFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+      const body = JSON.parse(init!.body as string);
+      // Codex 后端只说 SSE，且不该留存对话
+      expect(body.stream).toBe(true);
+      expect(body.store).toBe(false);
+      // system 消息应该合进 instructions，而不是塞进 input
+      expect(body.instructions).toBe("你是一个助手");
+      expect(body.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "你好" }] }]);
+      expect(init!.headers).toMatchObject({
+        Authorization: "Bearer test-access-token",
+        "chatgpt-account-id": "acct_test",
+      });
+      return sseCompletedResponse("你好，我是 Codex。", { input_tokens: 12, output_tokens: 8 });
+    });
+    bridge = await startCodexBridge(fakeAuth(), codexFetch);
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [
+        { role: "system", content: "你是一个助手" },
+        { role: "user", content: "你好" },
+      ],
+    });
+    expect(status).toBe(200);
+
+    const capability = getCapability("ChatGPT / Codex（订阅）")!;
+    const adapter = new OpenAICompatAdapter("codex", capability);
+    const parsed = adapter.parseResponse(json);
+    expect(parsed.text).toBe("你好，我是 Codex。");
+    expect(parsed.finishReason).toBe("stop");
+    expect(parsed.usage).toEqual({ input: 12, output: 8 });
+  });
+
+  // 回归：终结事件 output 为空、正文只在 delta / output_item.done 里。
+  // 这就是线上真实响应的样子，之前的实现在这里返回 502「没有返回任何文本」。
+  it("终结事件 output 为空时，仍能从 delta / output_item 拿到正文", async () => {
+    bridge = await startCodexBridge(
+      fakeAuth(),
+      vi.fn(async () => sseRealWorldShape("ok", { input_tokens: 8, output_tokens: 5 })),
+    );
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "say ok" }],
+    });
+
+    expect(status).toBe(200);
+    expect(json.choices[0].message.content).toBe("ok");
+    expect(json.usage).toMatchObject({ prompt_tokens: 8, completion_tokens: 5 });
+  });
+
+  it("只有 delta、连 output_item 都没有时也能拿到正文", async () => {
+    const ev = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+    bridge = await startCodexBridge(
+      fakeAuth(),
+      vi.fn(
+        async () =>
+          new Response(
+            ev("response.output_text.delta", { type: "response.output_text.delta", delta: "分两段" }) +
+              ev("response.output_text.delta", { type: "response.output_text.delta", delta: "拼起来" }) +
+              ev("response.completed", {
+                type: "response.completed",
+                response: { status: "completed", output: [], usage: { input_tokens: 1, output_tokens: 2 } },
+              }),
+            { status: 200 },
+          ),
+      ),
+    );
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(200);
+    expect(json.choices[0].message.content).toBe("分两段拼起来");
+  });
+
+  it("确实没有正文时，502 文案要报出可核对的事实而不是猜原因", async () => {
+    bridge = await startCodexBridge(
+      fakeAuth(),
+      vi.fn(
+        async () =>
+          new Response(
+            `event: response.completed\ndata: ${JSON.stringify({
+              type: "response.completed",
+              response: { status: "completed", output: [], usage: { input_tokens: 0, output_tokens: 0 } },
+            })}\n\n`,
+            { status: 200 },
+          ),
+      ),
+    );
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(502);
+    // 必须带上 status / usage 这些能直接核对的事实
+    expect(json.error.message).toMatch(/status=completed/);
+    expect(json.error.message).toMatch(/usage=0\/0/);
+    // 不许再出现"订阅额度用尽"这种没依据的猜测
+    expect(json.error.message).not.toMatch(/额度用尽/);
+  });
+
+  // 上游在 SSE 里回 error 事件时，必须把它的原话透出来。
+  // 这条是踩坑后补的：早先实现把 error 内容收进变量却从不使用，真实原因被
+  // 自造的"没有返回任何文本"盖掉，排查被带偏了两轮。
+  it("上游 error 事件的原文必须出现在返回的错误里", async () => {
+    const ev = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+    bridge = await startCodexBridge(
+      fakeAuth(),
+      vi.fn(
+        async () =>
+          new Response(
+            ev("response.created", { type: "response.created", response: { status: "in_progress" } }) +
+              ev("error", { type: "error", error: { message: "Something specific went wrong upstream." } }) +
+              ev("response.failed", { type: "response.failed", response: { status: "failed" } }),
+            { status: 200 },
+          ),
+      ),
+    );
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(502);
+    expect(json.error.message).toMatch(/Something specific went wrong upstream/);
+    // 绝不能再退化成那句自造的话
+    expect(json.error.message).not.toMatch(/没有返回任何文本/);
+  });
+
+  it("上游临时过载会自动重试，重试成功就正常返回", async () => {
+    const ev = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+    let calls = 0;
+    const codexFetch = vi.fn(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(
+          ev("response.created", { type: "response.created", response: { status: "in_progress" } }) +
+            ev("error", {
+              type: "error",
+              error: { message: "Our servers are currently overloaded. Please try again later." },
+            }),
+          { status: 200 },
+        );
+      }
+      return sseRealWorldShape("ok", { input_tokens: 8, output_tokens: 5 });
+    });
+    bridge = await startCodexBridge(fakeAuth(), codexFetch);
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(200);
+    expect(calls).toBe(2);
+    expect(json.choices[0].message.content).toBe("ok");
+  });
+
+  it("持续过载时给出「这是上游容量问题」的定性，别让人去查配置", async () => {
+    const ev = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+    let calls = 0;
+    const codexFetch = vi.fn(async () => {
+      calls++;
+      return new Response(
+        ev("response.created", { type: "response.created", response: { status: "in_progress" } }) +
+          ev("error", {
+            type: "error",
+            error: { message: "Our servers are currently overloaded. Please try again later." },
+          }),
+        { status: 200 },
+      );
+    });
+    bridge = await startCodexBridge(fakeAuth(), codexFetch);
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.6-sol",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(502);
+    expect(calls).toBe(3); // 首次 + 两次退避重试
+    expect(json.error.message).toMatch(/overloaded/i);
+    expect(json.error.message).toMatch(/临时容量问题/);
+  });
+
+  it("非临时错误（比如模型不支持）不重试，直接报出来", async () => {
+    let calls = 0;
+    const codexFetch = vi.fn(async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({ detail: "The 'gpt-5.1-codex' model is not supported when using Codex with a ChatGPT account." }),
+        { status: 400 },
+      );
+    });
+    bridge = await startCodexBridge(fakeAuth(), codexFetch);
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(502);
+    expect(calls).toBe(1); // 不该浪费时间重试
+    expect(json.error.message).toMatch(/not supported when using Codex/);
+  });
+
+  it("上游 401 时强制刷新一次并重试", async () => {
+    let calls = 0;
+    const auth = fakeAuth({
+      getValidAccessTokenImpl: vi.fn().mockResolvedValue({ accessToken: "stale", accountId: "acct_test" }),
+    });
+    const codexFetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      calls++;
+      const headers = init!.headers as Record<string, string>;
+      if (headers.Authorization === "Bearer stale") {
+        return new Response("", { status: 401 });
+      }
+      return sseCompletedResponse("刷新后成功", { input_tokens: 1, output_tokens: 1 });
+    });
+    bridge = await startCodexBridge(auth, codexFetch);
+
+    const { status, json } = await postChatCompletions(bridge, {
+      model: "gpt-5.1-codex",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(status).toBe(200);
+    expect(calls).toBe(2);
+    expect(json.choices[0].message.content).toBe("刷新后成功");
+    expect(auth.forceRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("404 给非 /v1/chat/completions 路径", async () => {
+    bridge = await startCodexBridge(fakeAuth(), noUpstream);
+    const res = await fetch(`${bridge.baseUrl.replace(/\/v1$/, "")}/v1/models`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${bridge.token}` },
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/main/orchestrator/vendors/codex-bridge.ts
+++ b/src/main/orchestrator/vendors/codex-bridge.ts
@@ -1,0 +1,518 @@
+// Codex 桥 —— 用 ChatGPT 订阅（Plus/Pro/Team）驱动 Chat 模式，不需要 API Key
+//
+// 设计动机（跟 claude-code-bridge.ts 是同一个理由，抄的同一个思路）：
+//   ChatVendorAdapter.buildRequest() 返回 HttpRequest，调度层自己发 fetch；
+//   capabilities 的 transport 只有 "openai" | "anthropic" 两种封闭联合。
+//   Codex 后端说的是 Responses API（POST /responses，SSE-only，Bearer + accountId
+//   header），跟 OpenAICompatAdapter 生成的 Chat Completions 请求完全是两个协议。
+//
+//   所以还是反过来做：main 进程里起一个只绑 127.0.0.1 的最小 HTTP 服务，对外说
+//   Chat Completions 协议（POST /v1/chat/completions），对内把请求翻译成 Responses
+//   API 打给 https://chatgpt.com/backend-api/codex/responses，用 codex-oauth-auth
+//   管的 OAuth token 鉴权。这样 openai-adapter / chat-loop / capabilities 一行都
+//   不用改，新厂商只是"baseUrl 恰好指向本机"的普通 OpenAI 兼容厂商。
+//
+// 边界（和 Claude Code 桥一样，不是偷懒）：
+//   只支持 Chat 模式。Work 模式（CITA → Action Gate → Native FC）要求厂商侧提供
+//   tools + structured output；把 Cyrene 的工具定义翻译成 Responses API 自己的
+//   function-tool 格式、再把结果对回 Native FC 期望的形状，是明显更大也更脆的一块
+//   工作，而且不是这次要做的事。请求里带 tools / tool_choice 时直接 400。
+//
+// 鉴权：只监听回环地址，另外要求请求带上启动时随机生成的 bridge token——
+// 挡的是同机其它进程乱打这个端口，不是防外网（回环本来就出不去）。
+// 这个 bridge token 跟 Codex 那边真正的 OAuth access token是两回事：前者是 Cyrene
+// 内部「调度层 → 本地桥」这一跳的门禁，后者是「本地桥 → chatgpt.com」这一跳的凭据，
+// 由 CodexOAuthAuth.getValidAccessToken() 负责拿、负责刷新。
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { CodexOAuthAuth } from "./codex-oauth-auth";
+import { proxyAwareFetch, type FetchLike } from "./proxy-fetch";
+
+const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+/** 请求体上限，防跑飞的 prompt 把 main 进程内存吃掉。 */
+const MAX_BODY_BYTES = 8 * 1024 * 1024;
+/** 调用方没指定 model 时的兜底。必须是 Codex /models 列出的 slug。 */
+const DEFAULT_MODEL = "gpt-5.6-sol";
+/**
+ * 上游临时故障的重试退避。
+ *
+ * 实测数据（gpt-5.6-sol）：失败很快回来（1～2 秒），成功要 5～9 秒（模型在推理）。
+ * 而 Cyrene 的"测试连接"只给 15 秒预算（openai-adapter.ts 里的 AbortController），
+ * 所以重试次数和退避都必须克制——重试把自己拖过 15 秒，用户看到的是"卡死超时"，
+ * 比老老实实回一个"上游过载"更难排查。
+ */
+const TRANSIENT_BACKOFF_MS = [500, 1200];
+/**
+ * 重试的总时间预算：超过这个点就不再开新一轮，直接把上游错误报出去。
+ * 光靠"最多重试 N 次"控不住总时长——每轮耗时是上游说了算的。
+ */
+const TRANSIENT_RETRY_BUDGET_MS = 9_000;
+
+/**
+ * 判断是不是"等一会儿再试就好"的上游故障。
+ * 这些文案是实测抓到的原文，不是照着文档猜的。
+ */
+function isTransientUpstreamError(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return (
+    /servers are currently overloaded/i.test(msg) ||
+    /try again later/i.test(msg) ||
+    /An error occurred while processing your request/i.test(msg) ||
+    /\bHTTP (429|500|502|503|504)\b/.test(msg)
+  );
+}
+
+export interface CodexBridgeHandle {
+  /** 直接填进 settings 的 baseUrl（已含 /v1）。 */
+  baseUrl: string;
+  /** 直接填进 settings 的 API Key 位置——bridge 自己的门禁 token，不是 OAuth token。 */
+  token: string;
+  port: number;
+  close(): Promise<void>;
+}
+
+interface WireContentBlock {
+  type: string;
+  text?: string;
+  [k: string]: unknown;
+}
+
+interface WireMessage {
+  role: string;
+  content?: string | WireContentBlock[];
+}
+
+interface WireRequest {
+  model?: string;
+  messages?: WireMessage[];
+  tools?: unknown[];
+  tool_choice?: unknown;
+  stream?: boolean;
+}
+
+function flattenContent(content: WireMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(b => b?.type === "text" && typeof b.text === "string")
+    .map(b => b.text as string)
+    .join("\n");
+}
+
+/** system/developer 消息拼进 instructions；user/assistant 转 Responses input items。 */
+function toResponsesPayload(messages: WireMessage[]): { instructions: string; input: unknown[] } {
+  const instructionParts: string[] = [];
+  const input: unknown[] = [];
+  for (const m of messages) {
+    if (m.role === "system" || m.role === "developer") {
+      const text = flattenContent(m.content);
+      if (text) instructionParts.push(text);
+      continue;
+    }
+    if (m.role === "user") {
+      input.push({ role: "user", content: [{ type: "input_text", text: flattenContent(m.content) }] });
+      continue;
+    }
+    if (m.role === "assistant") {
+      input.push({ role: "assistant", content: [{ type: "output_text", text: flattenContent(m.content) }] });
+      continue;
+    }
+    // role: "tool" 之类：这条桥不支持 Work 模式，正常情况下调用方也不会带这种消息进来。
+  }
+  return { instructions: instructionParts.join("\n\n"), input };
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+/** OpenAI 的错误信封，让 OpenAICompatAdapter 的报错路径拿到可读文案。 */
+function sendError(res: ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: { message, type: "invalid_request_error" } });
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("请求体超过 8MB 上限"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function tokenMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function extractToken(req: IncomingMessage): string {
+  const apiKey = req.headers["x-api-key"];
+  if (typeof apiKey === "string" && apiKey) return apiKey;
+  const auth = req.headers.authorization;
+  if (typeof auth === "string" && auth.startsWith("Bearer ")) return auth.slice(7);
+  return "";
+}
+
+// ── Responses API 的 SSE 收集：只关心最终态，不做增量流式转发（Chat 模式非流式）。 ──
+const TERMINAL_EVENT_TYPES = new Set([
+  "response.completed",
+  "response.failed",
+  "response.cancelled",
+  "response.canceled",
+  "response.incomplete",
+  "error",
+]);
+
+interface CollectedResponse {
+  text: string;
+  finishReason: string;
+  usage: { input: number; output: number };
+}
+
+/** 从一组 output item 里抠出 output_text 文本。 */
+function extractTextFromItems(items: unknown[]): string {
+  const parts: string[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const content = (item as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block && typeof block === "object" && (block as { type?: unknown }).type === "output_text") {
+        const text = (block as { text?: unknown }).text;
+        if (typeof text === "string") parts.push(text);
+      }
+    }
+  }
+  return parts.join("");
+}
+
+async function collectCodexResponse(body: ReadableStream<Uint8Array>): Promise<CollectedResponse> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let latestResponse: Record<string, unknown> | undefined;
+  let latestErrorMessage: string | undefined;
+  // 正文的三个来源，按可靠性从高到低兜底。见下面 finalize() 的注释。
+  let deltaText = "";
+  const outputItems = new Map<string, unknown>();
+
+  /**
+   * 为什么要三重兜底（这不是防御性编程，是实测出来的）：
+   * 实际抓到的 gpt-5.6-sol 响应里，终结事件 response.completed 的 output 是**空数组**，
+   * 正文只出现在中途的 response.output_text.delta（delta="ok"）和
+   * response.output_item.done（item 里带完整 content）两处。
+   * 只读 response.output 会得到空字符串，然后误报成"订阅额度用尽"。
+   * 参考实现（EvanZhouDev/openai-oauth 的 collectCompletedResponseFromSse）也是这么兜的：
+   * 终结响应 output 为空时，用中途累积的 item 顶上。
+   */
+  const finalize = (): CollectedResponse => {
+    const response = latestResponse ?? {};
+    const fromResponse = extractTextFromItems(Array.isArray(response.output) ? response.output : []);
+    const fromItems = extractTextFromItems([...outputItems.values()]);
+    const usage = response.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+    const text = fromResponse || fromItems || deltaText;
+
+    // 上游明确报错时，必须把它的原话带出去。
+    // 这里踩过坑：早先的实现把 error 事件的内容收进变量后就再没用过——只要流里出现过
+    // 任何 response 对象，报错路径就走不到，于是上游真正的失败原因被"没有返回任何文本"
+    // 这句自造的话盖掉，排查方向被带偏了两轮。宁可把上游原文透出来。
+    if (!text) {
+      const responseError = response.error as { message?: unknown } | null | undefined;
+      const upstream =
+        latestErrorMessage ??
+        (typeof responseError?.message === "string" ? responseError.message : undefined);
+      if (upstream) {
+        const status = typeof response.status === "string" ? response.status : "unknown";
+        throw new Error(`Codex 上游报错（status=${status}）：${upstream}`);
+      }
+    }
+
+    return {
+      text,
+      finishReason: typeof response.status === "string" ? response.status : "stop",
+      usage: { input: usage?.input_tokens ?? 0, output: usage?.output_tokens ?? 0 },
+    };
+  };
+
+  const processBlock = (block: string): "continue" | "terminal" => {
+    let eventType: string | undefined;
+    const dataLines: string[] = [];
+    for (const line of block.split(/\r?\n/)) {
+      if (line.startsWith("event:")) eventType = line.slice(6).trim();
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trimStart());
+    }
+    const data = dataLines.join("\n");
+    if (!data || data === "[DONE]") return "continue";
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return "continue";
+    }
+    if (eventType === "error" || parsed.type === "error") {
+      const err = parsed.error as { message?: unknown } | undefined;
+      latestErrorMessage = typeof err?.message === "string" ? err.message : JSON.stringify(parsed);
+    }
+    const type = typeof parsed.type === "string" ? parsed.type : undefined;
+    // 流式正文增量
+    if (type === "response.output_text.delta" && typeof parsed.delta === "string") {
+      deltaText += parsed.delta;
+    }
+    // 带 id 的 output item（response.output_item.added / .done）——按 id 覆盖，.done 会盖掉 .added
+    const item = parsed.item;
+    if (item && typeof item === "object" && typeof (item as { id?: unknown }).id === "string") {
+      outputItems.set((item as { id: string }).id, item);
+    }
+    const response = parsed.response;
+    if (response && typeof response === "object") {
+      latestResponse = response as Record<string, unknown>;
+    }
+    const status = latestResponse?.status;
+    const terminal =
+      (eventType && TERMINAL_EVENT_TYPES.has(eventType)) ||
+      (type && TERMINAL_EVENT_TYPES.has(type)) ||
+      (typeof status === "string" && ["completed", "failed", "cancelled", "canceled", "incomplete"].includes(status));
+    return terminal ? "terminal" : "continue";
+  };
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const blocks = buffer.split(/\r?\n\r?\n/);
+      buffer = blocks.pop() ?? "";
+      for (const block of blocks) {
+        if (block.trim().length === 0) continue;
+        if (processBlock(block) === "terminal" && latestResponse) return finalize();
+      }
+    }
+    // 流自然结束前可能还剩最后一个未被空行分隔的块
+    if (buffer.trim().length > 0) processBlock(buffer);
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (latestResponse || deltaText || outputItems.size > 0) return finalize();
+  throw new Error(`Codex 没有返回完整响应${latestErrorMessage ? `：${latestErrorMessage}` : "。"}`);
+}
+
+async function callCodexResponses(
+  accessToken: string,
+  accountId: string,
+  model: string,
+  instructions: string,
+  input: unknown[],
+  fetchImpl: FetchLike,
+): Promise<CollectedResponse> {
+  const res = await fetchImpl(CODEX_RESPONSES_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "chatgpt-account-id": accountId,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      instructions,
+      input,
+      store: false,
+      stream: true,
+      include: ["reasoning.encrypted_content"],
+    }),
+  });
+
+  if (res.status === 401) {
+    const err = new Error("Codex 后端返回 401") as Error & { codexUnauthorized: true };
+    err.codexUnauthorized = true;
+    throw err;
+  }
+  if (!res.ok || !res.body) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Codex 后端调用失败：HTTP ${res.status} ${text.slice(0, 300)}`);
+  }
+  return collectCodexResponse(res.body);
+}
+
+async function handleChatCompletions(
+  req: IncomingMessage,
+  res: ServerResponse,
+  bridgeToken: string,
+  auth: CodexOAuthAuth,
+  fetchImpl: FetchLike,
+): Promise<void> {
+  if (!tokenMatches(extractToken(req), bridgeToken)) {
+    sendError(res, 401, "Codex 桥 token 不匹配：请把设置里的 API Key 换成启动日志里的 token。");
+    return;
+  }
+
+  let body: WireRequest;
+  try {
+    body = JSON.parse(await readBody(req)) as WireRequest;
+  } catch (e) {
+    sendError(res, 400, `请求体解析失败：${e instanceof Error ? e.message : String(e)}`);
+    return;
+  }
+
+  // Work 模式硬拦。见文件头"边界"一节。
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    sendError(
+      res,
+      400,
+      "ChatGPT / Codex（订阅）只支持 Chat 模式。Work 模式需要厂商侧 function calling，" +
+        "把 Cyrene 的工具协议翻译到 Responses API 是另一块工作，这里没做。" +
+        "请把 Work 模式切到配 API Key 的 OpenAI 兼容厂商。",
+    );
+    return;
+  }
+  if (body.tool_choice !== undefined) {
+    sendError(res, 400, "ChatGPT / Codex（订阅）不支持 tool_choice：这是 Work 模式路径，请改用 API Key 厂商。");
+    return;
+  }
+  if (body.stream === true) {
+    sendError(res, 400, "Codex 桥暂不支持流式：Chat 模式当前走非流式路径。");
+    return;
+  }
+
+  const status = await auth.getStatus();
+  if (!status.loggedIn) {
+    sendError(res, 401, "还没有登录 ChatGPT：请去设置里点击「登录 ChatGPT」完成 OAuth 授权。");
+    return;
+  }
+
+  const { instructions, input } = toResponsesPayload(body.messages ?? []);
+  const model = body.model ?? DEFAULT_MODEL;
+
+  try {
+    let token = await auth.getValidAccessToken();
+    let result: CollectedResponse | undefined;
+    let refreshedOnce = false;
+    let transientRetries = 0;
+    const startedAt = Date.now();
+
+    // 两个计数器都只增不减且各有上限，循环必然终止。
+    for (;;) {
+      try {
+        result = await callCodexResponses(token.accessToken, token.accountId, model, instructions, input, fetchImpl);
+        break;
+      } catch (e) {
+        // 401：可能是 60s 提前刷新窗口之外的过期竞态，强制刷新一次立刻重试（不退避）。
+        if ((e as { codexUnauthorized?: true }).codexUnauthorized && !refreshedOnce) {
+          refreshedOnce = true;
+          token = await auth.forceRefresh();
+          continue;
+        }
+        // 上游临时性故障。实测很常见：同一个请求这次回
+        // "Our servers are currently overloaded. Please try again later."，
+        // 过几秒重发就成功了，跟请求内容无关。上游自己都写了让重试，
+        // 不该把这种失败原样甩给用户。
+        if (isTransientUpstreamError(e)) {
+          const backoff = TRANSIENT_BACKOFF_MS[transientRetries];
+          const withinBudget = Date.now() - startedAt + (backoff ?? 0) < TRANSIENT_RETRY_BUDGET_MS;
+          if (transientRetries < TRANSIENT_BACKOFF_MS.length && withinBudget) {
+            await new Promise(r => setTimeout(r, backoff));
+            transientRetries++;
+            continue;
+          }
+          throw new Error(
+            `${e instanceof Error ? e.message : String(e)}` +
+              `（已重试 ${transientRetries} 次仍失败。这是 OpenAI 侧的临时容量问题，` +
+              `不是模型名或配置写错了，稍后再试即可。）`,
+          );
+        }
+        throw e;
+      }
+    }
+    if (!result) throw new Error("Codex 调用未产生结果。");
+
+    if (!result.text) {
+      // 别再瞎猜原因了。之前这里写的是"可能是订阅额度用尽"，而真实原因是 SSE 解析
+      // 漏了 delta/item 两个正文来源，害得排查方向整个跑偏。把能确定的事实报出来。
+      sendError(
+        res,
+        502,
+        `Codex 返回了响应但没有可用文本（status=${result.finishReason}，` +
+          `usage=${result.usage.input}/${result.usage.output}）。` +
+          `如果 usage 是 0/0，通常是模型名不对；模型名请用 /models 里列出的 slug。`,
+      );
+      return;
+    }
+
+    sendJson(res, 200, {
+      id: `chatcmpl_codex_${randomBytes(8).toString("hex")}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: result.text },
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: result.usage.input,
+        completion_tokens: result.usage.output,
+        total_tokens: result.usage.input + result.usage.output,
+      },
+    });
+  } catch (e) {
+    sendError(res, 502, `Codex 调用失败：${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+export function startCodexBridge(
+  auth: CodexOAuthAuth,
+  /** 缺省走 Chromium 网络栈（含代理）；测试注入假实现。见 proxy-fetch.ts 的说明。 */
+  fetchImpl: FetchLike = proxyAwareFetch,
+): Promise<CodexBridgeHandle> {
+  const token = randomBytes(24).toString("hex");
+
+  const server: Server = createServer((req, res) => {
+    if (req.method !== "POST" || !req.url?.startsWith("/v1/chat/completions")) {
+      sendError(res, 404, "Codex 桥只提供 POST /v1/chat/completions。");
+      return;
+    }
+    void handleChatCompletions(req, res, token, auth, fetchImpl).catch(e => {
+      if (!res.headersSent) {
+        sendError(res, 500, `桥内部错误：${e instanceof Error ? e.message : String(e)}`);
+      }
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    // 只绑回环：这个端口不该被局域网看见。端口用 0 让内核分配，跟 OAuth 回调用的
+    // 固定端口 1455 是两码事——那个由 OpenAI 客户端注册写死，这个纯粹是 Cyrene
+    // 内部调度层访问本地桥用的，随便分配都行。
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("[CodexBridge] 拿不到监听端口"));
+        return;
+      }
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        token,
+        port: address.port,
+        close: () => new Promise<void>(done => server.close(() => done())),
+      });
+    });
+  });
+}

--- a/src/main/orchestrator/vendors/codex-oauth-auth.test.ts
+++ b/src/main/orchestrator/vendors/codex-oauth-auth.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createHmac } from "node:crypto";
+
+// Mock electron 的 safeStorage（不需要真钥匙串）——跟 channels/settings-store.test.ts 同套路。
+let safeStorageEnabled = true;
+const encState = new Map<string, string>();
+
+vi.mock("electron", () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => safeStorageEnabled,
+    encryptString: (plain: string) => {
+      const fake = Buffer.from("ENC(" + plain + ")").toString("base64");
+      encState.set(plain, fake);
+      return Buffer.from(fake, "base64");
+    },
+    decryptString: (buf: Buffer) => {
+      const b64 = buf.toString("base64");
+      for (const [plain, stored] of encState.entries()) {
+        if (stored === b64) return plain;
+      }
+      throw new Error("mock decrypt failed");
+    },
+  },
+}));
+
+// 必须在 mock 之后 import
+// eslint-disable-next-line import/first
+import { CodexOAuthAuth, decodeJwtClaims, deriveAccountId } from "./codex-oauth-auth";
+
+/**
+ * 模拟浏览器把授权回调打回本地回环。
+ *
+ * login() 里 openUrl 是同步回调，此时回调服务器的 listen() 可能还没完成绑定
+ * （真实场景里浏览器跳转耗时远长于此，不会撞上；测试里用 fetch 模拟瞬间回调就会撞上），
+ * 所以用短重试代替真实浏览器的延迟。
+ *
+ * 绝不抛出：调用方是 fire-and-forget（openUrl 是同步的，没法 await）。
+ * 一旦这里抛出就是没人接的 unhandled rejection —— 而 login() 成功后回调服务器立刻
+ * 关闭，在途的 fetch 必然失败，于是 vitest worker 会被整个带崩（表现为
+ * "Worker exited unexpectedly"，而不是某条用例失败，极难定位）。
+ * 真正的断言在 login() 的返回值上，这里失败自然会体现为 login 超时/失败。
+ */
+async function postCallbackWithRetry(url: string, attempts = 20): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      await fetch(url);
+      return;
+    } catch {
+      await new Promise(r => setTimeout(r, 10));
+    }
+  }
+}
+
+/**
+ * 端口 1455 是 OpenAI 客户端注册写死的，多个测试背靠背 listen/close 同一个端口时，
+ * Windows 偶尔要多等一拍才会真正释放（server.close() 不等 socket 完全释放就返回）。
+ * 只在明确是"端口占用"这一类错误时重试，state 不匹配等真实业务错误照样立即冒泡。
+ */
+async function loginRetryingPortConflict(
+  auth: CodexOAuthAuth,
+  attempts = 5,
+): Promise<{ accountId: string }> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await auth.login();
+    } catch (err) {
+      const isPortConflict = err instanceof Error && /已被占用/.test(err.message);
+      if (!isPortConflict || i === attempts - 1) throw err;
+      await new Promise(r => setTimeout(r, 50));
+    }
+  }
+  throw new Error("unreachable");
+}
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  const header = b64url({ alg: "none", typ: "JWT" });
+  const body = b64url(payload);
+  // 签名部分不校验，测试不需要真签名。
+  const sig = createHmac("sha256", "unused").update(`${header}.${body}`).digest("base64url");
+  return `${header}.${body}.${sig}`;
+}
+
+describe("decodeJwtClaims / deriveAccountId", () => {
+  it("从 https://api.openai.com/auth claim 里拿 chatgpt_account_id", () => {
+    const idToken = fakeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_123" } });
+    expect(deriveAccountId(idToken, undefined)).toBe("acct_123");
+  });
+
+  it("回退到顶层 chatgpt_account_id", () => {
+    const idToken = fakeJwt({ chatgpt_account_id: "acct_top" });
+    expect(deriveAccountId(idToken, undefined)).toBe("acct_top");
+  });
+
+  it("再回退到 organizations[0].id", () => {
+    const idToken = fakeJwt({ organizations: [{ id: "org_1" }] });
+    expect(deriveAccountId(idToken, undefined)).toBe("org_1");
+  });
+
+  it("id_token 解不出时退到 access_token", () => {
+    const accessToken = fakeJwt({ chatgpt_account_id: "acct_from_access" });
+    expect(deriveAccountId(undefined, accessToken)).toBe("acct_from_access");
+  });
+
+  it("两个 token 都没有可用 claim 时返回 undefined", () => {
+    expect(deriveAccountId(fakeJwt({}), fakeJwt({}))).toBeUndefined();
+  });
+
+  it("非法 token（非三段式）返回 undefined claims", () => {
+    expect(decodeJwtClaims("not-a-jwt")).toBeUndefined();
+    expect(decodeJwtClaims(undefined)).toBeUndefined();
+  });
+});
+
+describe("CodexOAuthAuth", () => {
+  let tmpDir: string;
+  let sessionPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-oauth-test-"));
+    sessionPath = path.join(tmpDir, "codex-oauth-session.json");
+    encState.clear();
+    safeStorageEnabled = true;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it("未登录时 getStatus 返回 loggedIn: false，getValidAccessToken 抛出明确错误", async () => {
+    const auth = new CodexOAuthAuth(sessionPath, tmpDir, () => {});
+    expect(await auth.getStatus()).toEqual({ loggedIn: false });
+    await expect(auth.getValidAccessToken()).rejects.toThrow(/未登录/);
+  });
+
+  it("并发 getValidAccessToken 在 token 过期时只触发一次刷新（加锁）", async () => {
+    let refreshCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://auth.openai.com/oauth/token");
+      refreshCalls++;
+      // 制造一点延迟，确保两次并发调用真的会撞上同一次 in-flight 刷新
+      await new Promise(r => setTimeout(r, 20));
+      return new Response(
+        JSON.stringify({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }),
+        { status: 200 },
+      );
+    });
+    const auth = new CodexOAuthAuth(sessionPath, tmpDir, () => {}, fetchMock);
+    // 直接走一次真实登录不现实（需要真端口 1455 + 真浏览器），这里通过内部字段注入一个
+    // 已过期、带 refreshToken 的会话，只测 getValidAccessToken 的刷新加锁行为。
+    (auth as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "old-access",
+      refreshToken: "refresh-abc",
+      expiresAt: Date.now() - 1000,
+      accountId: "acct_1",
+    };
+    (auth as unknown as { loaded: boolean }).loaded = true;
+
+    const [a, b] = await Promise.all([auth.getValidAccessToken(), auth.getValidAccessToken()]);
+    expect(refreshCalls).toBe(1);
+    expect(a.accessToken).toBe("new-access");
+    expect(b.accessToken).toBe("new-access");
+  });
+
+  it("刷新使用 JSON 编码，换 token 用 form 编码——两者不能搞反", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({ "Content-Type": "application/json" });
+      const body = JSON.parse(init!.body as string);
+      expect(body).toMatchObject({ grant_type: "refresh_token", refresh_token: "refresh-xyz" });
+      return new Response(JSON.stringify({ access_token: "next", expires_in: 3600 }), { status: 200 });
+    });
+    const auth = new CodexOAuthAuth(sessionPath, tmpDir, () => {}, fetchMock);
+    (auth as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "old",
+      refreshToken: "refresh-xyz",
+      expiresAt: Date.now() - 1000,
+      accountId: "acct_1",
+    };
+    (auth as unknown as { loaded: boolean }).loaded = true;
+
+    await auth.getValidAccessToken();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("刷新失败（无 refreshToken）时给出清楚的重新登录提示", async () => {
+    const auth = new CodexOAuthAuth(sessionPath, tmpDir, () => {});
+    (auth as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "old",
+      expiresAt: Date.now() - 1000,
+      accountId: "acct_1",
+    };
+    (auth as unknown as { loaded: boolean }).loaded = true;
+    await expect(auth.getValidAccessToken()).rejects.toThrow(/重新登录/);
+  });
+
+  it("会话加密落盘后能在新实例里还原（safeStorage 可用时）", async () => {
+    const refreshOk = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ access_token: "a2", refresh_token: "r2", expires_in: 3600 }),
+        { status: 200 },
+      ),
+    );
+    const auth1 = new CodexOAuthAuth(sessionPath, tmpDir, () => {}, refreshOk);
+    (auth1 as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "a",
+      refreshToken: "r",
+      // 故意设成已过期：走 getValidAccessToken 的"未过期直接返回"分支不会写盘，
+      // 只有刷新路径才落盘，而刷新更贴近真实使用路径（比直接调私有 saveSession 好）。
+      expiresAt: Date.now() - 1000,
+      accountId: "acct_persist",
+    };
+    (auth1 as unknown as { loaded: boolean }).loaded = true;
+    await auth1.getValidAccessToken();
+
+    const auth2 = new CodexOAuthAuth(sessionPath, tmpDir, () => {});
+    const status = await auth2.getStatus();
+    expect(status).toEqual({ loggedIn: true, accountId: "acct_persist" });
+  });
+
+  it("safeStorage 不可用时回退机器指纹混淆，仍能 round-trip", async () => {
+    safeStorageEnabled = false;
+    const refreshOk = vi.fn(async () =>
+      new Response(JSON.stringify({ access_token: "a2", expires_in: 3600 }), { status: 200 }),
+    );
+    const auth1 = new CodexOAuthAuth(sessionPath, tmpDir, () => {}, refreshOk);
+    (auth1 as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "a",
+      refreshToken: "r",
+      expiresAt: Date.now() - 1000,
+      accountId: "acct_obf",
+    };
+    (auth1 as unknown as { loaded: boolean }).loaded = true;
+    await auth1.getValidAccessToken();
+
+    const raw = fs.readFileSync(sessionPath, "utf8");
+    expect(raw.startsWith("obf:")).toBe(true);
+
+    const auth2 = new CodexOAuthAuth(sessionPath, tmpDir, () => {});
+    expect(await auth2.getStatus()).toEqual({ loggedIn: true, accountId: "acct_obf" });
+  });
+
+  it("logout 清空会话并删除落盘文件", async () => {
+    const auth = new CodexOAuthAuth(sessionPath, tmpDir, () => {});
+    (auth as unknown as { session: unknown; loaded: boolean }).session = {
+      accessToken: "a",
+      expiresAt: Date.now() + 3600_000,
+      accountId: "acct_1",
+    };
+    (auth as unknown as { loaded: boolean }).loaded = true;
+    fs.writeFileSync(sessionPath, "plain:{}");
+
+    await auth.logout();
+    expect(await auth.getStatus()).toEqual({ loggedIn: false });
+    expect(fs.existsSync(sessionPath)).toBe(false);
+  });
+
+  // 端到端登录：真绑 127.0.0.1:1455（OpenAI 客户端注册写死的端口，测不了别的），
+  // 用真实 HTTP 请求模拟浏览器把授权码回传到 /auth/callback；换 token 那一跳注入假 fetch。
+  // 这是唯一一处验证 PKCE 请求参数形状（state/code_challenge/redirect_uri）的地方。
+  it("login() 端到端：state 匹配、redirect_uri 是字面量 localhost:1455、accountId 解得出来", async () => {
+    const idToken = fakeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_e2e" } });
+    const tokenFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://auth.openai.com/oauth/token");
+      const params = new URLSearchParams(init!.body as string);
+      expect(params.get("grant_type")).toBe("authorization_code");
+      expect(params.get("code")).toBe("test-code");
+      // code_verifier 必须回传，且是 PKCE 那一份（长度足够、URL-safe）
+      expect(params.get("code_verifier")).toMatch(/^[A-Za-z0-9_-]{43,}$/);
+      return new Response(
+        JSON.stringify({ access_token: "tok", refresh_token: "ref", id_token: idToken, expires_in: 3600 }),
+        { status: 200 },
+      );
+    });
+
+    const auth = new CodexOAuthAuth(
+      sessionPath,
+      tmpDir,
+      url => {
+        const parsed = new URL(url);
+        expect(parsed.origin).toBe("https://auth.openai.com");
+        expect(parsed.pathname).toBe("/oauth/authorize");
+        expect(parsed.searchParams.get("redirect_uri")).toBe("http://localhost:1455/auth/callback");
+        expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+        expect(parsed.searchParams.get("client_id")).toBe("app_EMoamEEZ73f0CkXaXp7hrann");
+        const state = parsed.searchParams.get("state");
+        expect(state).toBeTruthy();
+        // 模拟浏览器把授权服务器的回调打回本地回环——真实 TCP 请求，用的是全局 fetch，
+        // 跟注入的 tokenFetch 互不干扰（这正是注入比 stubGlobal 干净的地方）。
+        void postCallbackWithRetry(`http://127.0.0.1:1455/auth/callback?code=test-code&state=${state}`);
+      },
+      tokenFetch,
+    );
+
+    const result = await loginRetryingPortConflict(auth);
+    expect(result.accountId).toBe("acct_e2e");
+    expect(await auth.getStatus()).toEqual({ loggedIn: true, accountId: "acct_e2e" });
+    expect(tokenFetch).toHaveBeenCalledOnce();
+  });
+
+  it("login() 拒绝 state 不匹配的回调（CSRF 防护）", async () => {
+    // state 不匹配就该在回调那一步失败，绝不能走到换 token —— 用一个"被调用就炸"的
+    // fetch 把这条不变量钉住。
+    const mustNotBeCalled = vi.fn(async () => {
+      throw new Error("state 不匹配时不应该发起 token 交换");
+    });
+    const auth = new CodexOAuthAuth(
+      sessionPath,
+      tmpDir,
+      () => {
+        void postCallbackWithRetry("http://127.0.0.1:1455/auth/callback?code=test-code&state=wrong-state");
+      },
+      mustNotBeCalled,
+    );
+    await expect(loginRetryingPortConflict(auth)).rejects.toThrow(/state 不匹配/);
+    expect(mustNotBeCalled).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/orchestrator/vendors/codex-oauth-auth.ts
+++ b/src/main/orchestrator/vendors/codex-oauth-auth.ts
@@ -1,0 +1,516 @@
+// Codex（ChatGPT 订阅）OAuth —— PKCE 登录 + token 刷新 + 加密落盘
+//
+// 事实来源：不是这份文件作者自己猜的，是对着 EvanZhouDev/openai-oauth 的源码
+// （packages/core/src/runtime.ts、packages/openai-oauth/src/login.ts）核对过的：
+// - client_id 是 OpenAI Codex 的公开注册值（app_EMoamEEZ73f0CkXaXp7hrann），不可自定义。
+// - redirect_uri 必须是字面量 http://localhost:1455/auth/callback——host 用 "localhost"
+//   （不是 127.0.0.1）、端口 1455，两者都是客户端注册里写死的，换了会在换 token 那步报
+//   redirect_uri 不匹配。
+// - 换 token（authorization_code）是 form 编码；刷新（refresh_token）是 JSON 编码。
+//   这个不对称容易搞反。
+// - accountId 藏在 id_token（拿不到就退 access_token）这个 JWT 的
+//   claims["https://api.openai.com/auth"].chatgpt_account_id，没有就退顶层
+//   chatgpt_account_id，再没有就退 organizations[0].id。
+//
+// 不做的事：不读/不写 ~/.codex/auth.json——那是 Codex CLI 自己的凭据。跟它抢同一个
+// refresh_token 会导致其中一边刷新后另一边静默掉线（OAuth provider 刷新时通常会
+// 轮换 refresh_token 并让旧的失效）。自己走一遍登录，自己管自己的 token。
+import { createHash, randomBytes } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { safeStorage } from "electron";
+import { proxyAwareFetch, type FetchLike } from "./proxy-fetch";
+
+const ISSUER = "https://auth.openai.com";
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CALLBACK_PORT = 1455;
+const CALLBACK_PATH = "/auth/callback";
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const SCOPE = "openid profile email offline_access";
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+/** 提前刷新的余量：避免 token 恰好在请求飞行途中过期。 */
+const REFRESH_SLACK_MS = 60 * 1000;
+
+export interface CodexOAuthSession {
+  accessToken: string;
+  refreshToken?: string;
+  /** epoch ms */
+  expiresAt: number;
+  accountId: string;
+}
+
+export interface CodexOAuthStatus {
+  loggedIn: boolean;
+  accountId?: string;
+}
+
+// ── 加密落盘：safeStorage（OS 钥匙串）→ 机器指纹 XOR 混淆 → 明文兜底 ──────
+// 和 src/main/channels/settings-store.ts 的三级方案同思路；那边的 encryptField/
+// decryptField 没有 export，这里就近自带一份，别的模块（claude-code-bridge.ts 之类）
+// 也是各管各的存储，不是这个仓库缺一个共享 util。
+const ENC_PREFIX = "enc:";
+const OBF_PREFIX = "obf:";
+const PLAIN_PREFIX = "plain:";
+
+// 不缓存：isEncryptionAvailable() 本身就是个便宜的同步调用，缓存只会让"运行时环境
+// 变了但读到的还是旧值"这种情况（比如测试里切换可用性）读到过期结果，省不了什么。
+function isSafeStorageAvailable(): boolean {
+  try {
+    return safeStorage.isEncryptionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+function getMachineKey(userDataDir: string): Buffer {
+  const seed = `${userDataDir}::cyrene-codex-oauth-secret`;
+  return createHash("sha256").update(seed).digest().subarray(0, 16);
+}
+
+function xorWithKey(buf: Buffer, key: Buffer): Buffer {
+  const out = Buffer.alloc(buf.length);
+  for (let i = 0; i < buf.length; i++) {
+    // eslint-disable-next-line no-bitwise
+    out[i] = buf[i] ^ key[i % key.length];
+  }
+  return out;
+}
+
+function encryptBlob(plain: string, userDataDir: string): string {
+  if (!plain) return "";
+  if (isSafeStorageAvailable()) {
+    try {
+      return ENC_PREFIX + safeStorage.encryptString(plain).toString("base64");
+    } catch (err) {
+      console.warn("[CodexOAuth] safeStorage.encryptString 失败，回退混淆:", err);
+    }
+  }
+  const key = getMachineKey(userDataDir);
+  return OBF_PREFIX + xorWithKey(Buffer.from(plain, "utf8"), key).toString("base64");
+}
+
+function decryptBlob(stored: string, userDataDir: string): string {
+  if (!stored) return "";
+  if (stored.startsWith(ENC_PREFIX)) {
+    if (!isSafeStorageAvailable()) {
+      console.warn("[CodexOAuth] safeStorage 不可用，无法解密 enc: 字段");
+      return "";
+    }
+    try {
+      return safeStorage.decryptString(Buffer.from(stored.slice(ENC_PREFIX.length), "base64"));
+    } catch (err) {
+      console.warn("[CodexOAuth] safeStorage.decryptString 失败:", err);
+      return "";
+    }
+  }
+  if (stored.startsWith(OBF_PREFIX)) {
+    try {
+      const key = getMachineKey(userDataDir);
+      const buf = Buffer.from(stored.slice(OBF_PREFIX.length), "base64");
+      return xorWithKey(buf, key).toString("utf8");
+    } catch (err) {
+      console.warn("[CodexOAuth] 混淆解码失败:", err);
+      return "";
+    }
+  }
+  if (stored.startsWith(PLAIN_PREFIX)) return stored.slice(PLAIN_PREFIX.length);
+  return stored;
+}
+
+async function loadSession(sessionPath: string, userDataDir: string): Promise<CodexOAuthSession | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(sessionPath, "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    console.warn("[CodexOAuth] 读取会话文件失败:", e);
+    return null;
+  }
+  const plain = decryptBlob(raw.trim(), userDataDir);
+  if (!plain) return null;
+  try {
+    const parsed = JSON.parse(plain) as CodexOAuthSession;
+    if (typeof parsed.accessToken !== "string" || typeof parsed.accountId !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function saveSession(sessionPath: string, userDataDir: string, session: CodexOAuthSession): Promise<void> {
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+  const blob = encryptBlob(JSON.stringify(session), userDataDir);
+  const tmp = `${sessionPath}.tmp`;
+  await fs.writeFile(tmp, blob, "utf8");
+  await fs.rename(tmp, sessionPath);
+}
+
+async function clearSessionFile(sessionPath: string): Promise<void> {
+  await fs.rm(sessionPath, { force: true });
+}
+
+// ── PKCE ──────────────────────────────────────────────────────────────────
+interface PkceRequest {
+  state: string;
+  codeVerifier: string;
+  authorizationUrl: string;
+}
+
+function createPkceRequest(): PkceRequest {
+  const state = randomBytes(24).toString("base64url");
+  const codeVerifier = randomBytes(48).toString("base64url");
+  const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+
+  const url = new URL(`${ISSUER}/oauth/authorize`);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("scope", SCOPE);
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  // 参照现存实现带上；具体是否仍必需没有官方文档确认，原始需求文档提醒过这类细节会漂移。
+  url.searchParams.set("id_token_add_organizations", "true");
+  url.searchParams.set("codex_cli_simplified_flow", "true");
+
+  return { state, codeVerifier, authorizationUrl: url.toString() };
+}
+
+// ── 换 token / 刷新 ──────────────────────────────────────────────────────
+interface TokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  expiresIn?: number;
+}
+
+async function parseTokenResponse(res: Response): Promise<TokenResponse> {
+  const text = await res.text();
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const parsed = JSON.parse(text) as { error_description?: string; message?: string };
+      detail = parsed.error_description ?? parsed.message ?? "";
+    } catch {
+      // ignore，用空 detail
+    }
+    throw new Error(`Codex OAuth token 请求失败：HTTP ${res.status}${detail ? ` ${detail}` : ""}`);
+  }
+  let parsed: { access_token?: unknown; refresh_token?: unknown; id_token?: unknown; expires_in?: unknown };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("Codex OAuth token 响应不是合法 JSON。");
+  }
+  if (typeof parsed.access_token !== "string") {
+    throw new Error("Codex OAuth token 响应缺少 access_token。");
+  }
+  return {
+    accessToken: parsed.access_token,
+    refreshToken: typeof parsed.refresh_token === "string" ? parsed.refresh_token : undefined,
+    idToken: typeof parsed.id_token === "string" ? parsed.id_token : undefined,
+    expiresIn: typeof parsed.expires_in === "number" ? parsed.expires_in : undefined,
+  };
+}
+
+/**
+ * 授权码换 token —— form 编码。
+ *
+ * fetchImpl 必须是走代理的那个（见 proxy-fetch.ts）：auth.openai.com 在部分地区
+ * 直连会被回 403 unsupported_country_region_territory，而浏览器授权那步是通的，
+ * 症状会伪装成"OAuth 实现有 bug"。
+ */
+async function exchangeCode(
+  code: string,
+  codeVerifier: string,
+  fetchImpl: FetchLike,
+): Promise<TokenResponse> {
+  const res = await fetchImpl(`${ISSUER}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      code_verifier: codeVerifier,
+    }).toString(),
+  });
+  return parseTokenResponse(res);
+}
+
+/** 刷新 —— JSON 编码。和上面的 form 编码不是笔误，是两个端点约定不一样。 */
+async function refreshTokens(refreshToken: string, fetchImpl: FetchLike): Promise<TokenResponse> {
+  const res = await fetchImpl(`${ISSUER}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }),
+  });
+  return parseTokenResponse(res);
+}
+
+// ── JWT accountId 提取（只读 claim，不验签——读自己的 token 做路由用途） ──
+export function decodeJwtClaims(token: string | undefined): Record<string, unknown> | undefined {
+  if (typeof token !== "string" || !token.includes(".")) return undefined;
+  const parts = token.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const payload = Buffer.from(parts[1], "base64url").toString("utf8");
+    const parsed: unknown = JSON.parse(payload);
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function deriveAccountId(idToken: string | undefined, accessToken: string | undefined): string | undefined {
+  for (const token of [idToken, accessToken]) {
+    const claims = decodeJwtClaims(token);
+    if (!claims) continue;
+
+    const authClaim = claims["https://api.openai.com/auth"];
+    if (authClaim && typeof authClaim === "object") {
+      const id = (authClaim as Record<string, unknown>).chatgpt_account_id;
+      if (typeof id === "string" && id) return id;
+    }
+
+    const topLevel = claims.chatgpt_account_id;
+    if (typeof topLevel === "string" && topLevel) return topLevel;
+
+    const organizations = claims.organizations;
+    if (Array.isArray(organizations) && organizations.length > 0) {
+      const first = organizations[0] as Record<string, unknown> | undefined;
+      if (first && typeof first.id === "string" && first.id) return first.id;
+    }
+  }
+  return undefined;
+}
+
+// ── 本地回环回调服务器：只接 127.0.0.1 / ::1，端口 1455 是注册死的，不能换。 ──
+function listenOnce(server: Server, port: number, host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => {
+      server.removeListener("listening", onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function receiveCallback(expectedState: string): Promise<{ code: string }> {
+  const servers: Server[] = [];
+  let settled = false;
+  let resolveResult!: (v: { code: string }) => void;
+  let rejectResult!: (e: Error) => void;
+  const resultPromise = new Promise<{ code: string }>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+
+  const closeAll = () => {
+    for (const s of servers) {
+      try {
+        // closeAllConnections 强制断开还挂着的 keep-alive 连接——只调 close() 只是
+        // 停止接受新连接，已建立的连接会一直留着，下一次登录复用同一个端口时，
+        // 客户端的连接池可能复用这条老连接，把请求送进已经"退休"的旧 handler 闭包里，
+        // 导致新一轮登录莫名其妙收不到回调。
+        s.closeAllConnections?.();
+        s.close();
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const finish = (fn: () => void) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    closeAll();
+    fn();
+  };
+
+  const handler = (req: IncomingMessage, res: ServerResponse): void => {
+    const url = new URL(req.url ?? "/", `http://localhost:${CALLBACK_PORT}`);
+    if (url.pathname !== CALLBACK_PATH) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8", Connection: "close" });
+      res.end("Not found");
+      return;
+    }
+    const error = url.searchParams.get("error");
+    if (error) {
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8", Connection: "close" });
+      res.end("<html><body>ChatGPT 登录失败，可以关闭此页面。</body></html>");
+      finish(() => rejectResult(new Error(`Codex OAuth 授权失败：${error}`)));
+      return;
+    }
+    const state = url.searchParams.get("state");
+    const code = url.searchParams.get("code");
+    if (!code || state !== expectedState) {
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8", Connection: "close" });
+      res.end("<html><body>登录回调无效，可以关闭此页面。</body></html>");
+      finish(() => rejectResult(new Error("Codex OAuth 回调缺少 code 或 state 不匹配（可能的 CSRF）。")));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", Connection: "close" });
+    res.end("<html><body>登录成功，可以关闭此页面，回到 Cyrene。</body></html>");
+    finish(() => resolveResult({ code }));
+  };
+
+  const timer = setTimeout(() => {
+    finish(() => rejectResult(new Error("Codex 登录超时（5 分钟内未完成浏览器授权）。")));
+  }, LOGIN_TIMEOUT_MS);
+  timer.unref?.();
+
+  const hosts = ["127.0.0.1", "::1"];
+  let boundAny = false;
+  for (const host of hosts) {
+    const server = createServer(handler);
+    try {
+      await listenOnce(server, CALLBACK_PORT, host);
+      servers.push(server);
+      boundAny = true;
+    } catch (err) {
+      try {
+        server.close();
+      } catch {
+        // ignore
+      }
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "EADDRINUSE") {
+        clearTimeout(timer);
+        closeAll();
+        throw new Error(
+          `Codex 登录需要用 http://localhost:${CALLBACK_PORT}${CALLBACK_PATH} 接收回调，但端口 ${CALLBACK_PORT} ` +
+            `已被占用。这个端口是 OpenAI 客户端注册写死的，没法换——请先关掉占用该端口的进程再重试。`,
+        );
+      }
+      // EADDRNOTAVAIL / EAFNOSUPPORT（比如机器没开 IPv6）——忽略，继续试下一个 host。
+    }
+  }
+  if (!boundAny) {
+    clearTimeout(timer);
+    throw new Error("Codex 登录回调服务器启动失败：没有可用的本地回环地址。");
+  }
+
+  return resultPromise;
+}
+
+// ── 对外接口 ────────────────────────────────────────────────────────────
+export class CodexOAuthAuth {
+  private session: CodexOAuthSession | null = null;
+  private loaded = false;
+  private refreshing: Promise<CodexOAuthSession> | null = null;
+
+  constructor(
+    private readonly sessionPath: string,
+    private readonly userDataDir: string,
+    private readonly openUrl: (url: string) => void,
+    /** 缺省走 Chromium 网络栈（含代理）；测试注入假实现。见 proxy-fetch.ts 的说明。 */
+    private readonly fetchImpl: FetchLike = proxyAwareFetch,
+  ) {}
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    this.session = await loadSession(this.sessionPath, this.userDataDir);
+    this.loaded = true;
+  }
+
+  async getStatus(): Promise<CodexOAuthStatus> {
+    await this.ensureLoaded();
+    return this.session ? { loggedIn: true, accountId: this.session.accountId } : { loggedIn: false };
+  }
+
+  async logout(): Promise<void> {
+    await this.ensureLoaded();
+    this.session = null;
+    await clearSessionFile(this.sessionPath);
+  }
+
+  /** 跑一次完整登录：起本地回调服务器 → 打开系统浏览器 → 等回调 → 换 token → 落盘。 */
+  async login(): Promise<{ accountId: string }> {
+    const pkce = createPkceRequest();
+    const callbackPromise = receiveCallback(pkce.state);
+    this.openUrl(pkce.authorizationUrl);
+
+    const { code } = await callbackPromise;
+    const token = await exchangeCode(code, pkce.codeVerifier, this.fetchImpl);
+    const accountId = deriveAccountId(token.idToken, token.accessToken);
+    if (!accountId) {
+      throw new Error("Codex OAuth 登录成功但没能解出 accountId（token 里没找到 chatgpt_account_id）。");
+    }
+
+    const session: CodexOAuthSession = {
+      accessToken: token.accessToken,
+      refreshToken: token.refreshToken,
+      expiresAt: Date.now() + (token.expiresIn ?? 3600) * 1000,
+      accountId,
+    };
+    this.session = session;
+    this.loaded = true;
+    await saveSession(this.sessionPath, this.userDataDir, session);
+    return { accountId };
+  }
+
+  /** 取一个可用的 access token；快过期（60s 内）就刷新。并发调用共享同一次刷新。 */
+  async getValidAccessToken(): Promise<{ accessToken: string; accountId: string }> {
+    await this.ensureLoaded();
+    if (!this.session) {
+      throw new Error("Codex 未登录：请先在设置里点击「登录 ChatGPT」。");
+    }
+    if (Date.now() < this.session.expiresAt - REFRESH_SLACK_MS) {
+      return { accessToken: this.session.accessToken, accountId: this.session.accountId };
+    }
+    return this.refreshNow();
+  }
+
+  /** 上游返回 401 时的兜底：强制刷新一次再重试，不管 expiresAt 是否"看起来"还没到期。 */
+  async forceRefresh(): Promise<{ accessToken: string; accountId: string }> {
+    await this.ensureLoaded();
+    if (!this.session) {
+      throw new Error("Codex 未登录：请先在设置里点击「登录 ChatGPT」。");
+    }
+    return this.refreshNow();
+  }
+
+  private async refreshNow(): Promise<{ accessToken: string; accountId: string }> {
+    if (this.refreshing) {
+      const s = await this.refreshing;
+      return { accessToken: s.accessToken, accountId: s.accountId };
+    }
+    const current = this.session;
+    if (!current?.refreshToken) {
+      throw new Error("Codex 登录已过期且没有可用的 refresh_token，请重新登录。");
+    }
+    this.refreshing = (async (): Promise<CodexOAuthSession> => {
+      const token = await refreshTokens(current.refreshToken!, this.fetchImpl);
+      const accountId = deriveAccountId(token.idToken, token.accessToken) ?? current.accountId;
+      const next: CodexOAuthSession = {
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken ?? current.refreshToken,
+        expiresAt: Date.now() + (token.expiresIn ?? 3600) * 1000,
+        accountId,
+      };
+      this.session = next;
+      await saveSession(this.sessionPath, this.userDataDir, next);
+      return next;
+    })();
+    try {
+      const s = await this.refreshing;
+      return { accessToken: s.accessToken, accountId: s.accountId };
+    } finally {
+      this.refreshing = null;
+    }
+  }
+}

--- a/src/main/orchestrator/vendors/codex-oauth-bootstrap.ts
+++ b/src/main/orchestrator/vendors/codex-oauth-bootstrap.ts
@@ -1,0 +1,32 @@
+// 把 CodexOAuthAuth + Codex 桥 + IPC 注册串起来，供 main/index.ts 一次性调用。
+// 结构照抄 src/main/music/bootstrap.ts 的 bootstrap 惯例。
+import { app, shell } from "electron";
+import * as path from "node:path";
+import { CodexOAuthAuth } from "./codex-oauth-auth";
+import { startCodexBridge, type CodexBridgeHandle } from "./codex-bridge";
+import { registerCodexOAuthIpcHandlers } from "./codex-oauth-ipc";
+
+export interface CodexOAuthBootstrap {
+  auth: CodexOAuthAuth;
+  bridge: CodexBridgeHandle;
+  dispose(): Promise<void>;
+}
+
+export async function bootstrapCodexOAuth(): Promise<CodexOAuthBootstrap> {
+  const userDataDir = app.getPath("userData");
+  const sessionPath = path.join(userDataDir, "codex-oauth-session.json");
+  const auth = new CodexOAuthAuth(sessionPath, userDataDir, url => {
+    void shell.openExternal(url);
+  });
+  const bridge = await startCodexBridge(auth);
+  const disposeIpc = registerCodexOAuthIpcHandlers(auth, bridge);
+
+  return {
+    auth,
+    bridge,
+    dispose: async () => {
+      disposeIpc();
+      await bridge.close();
+    },
+  };
+}

--- a/src/main/orchestrator/vendors/codex-oauth-ipc.ts
+++ b/src/main/orchestrator/vendors/codex-oauth-ipc.ts
@@ -1,0 +1,46 @@
+// Codex OAuth 的 IPC 暴露层 —— 设置窗口的「登录 ChatGPT」按钮走这里。
+// 结构照抄 src/main/music/ipc-handlers.ts 的 register/dispose 惯例。
+import { ipcMain } from "electron";
+import { IPC } from "../../../shared/ipc-channels";
+import type { CodexOAuthAuth } from "./codex-oauth-auth";
+import type { CodexBridgeHandle } from "./codex-bridge";
+
+export type CodexOAuthIpcResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+function wrap<T>(fn: () => Promise<T>): Promise<CodexOAuthIpcResult<T>> {
+  return fn().then(
+    data => ({ ok: true as const, data }),
+    (err: unknown) => ({ ok: false as const, error: err instanceof Error ? err.message : String(err) }),
+  );
+}
+
+export interface CodexOAuthStatusPayload {
+  loggedIn: boolean;
+  accountId?: string;
+  /** 桥的 baseUrl/token——登录成功后设置面板据此自动填 Base URL / API Key。 */
+  bridge: { baseUrl: string; token: string };
+}
+
+export function registerCodexOAuthIpcHandlers(auth: CodexOAuthAuth, bridge: CodexBridgeHandle): () => void {
+  const channels: string[] = [];
+
+  ipcMain.handle(IPC.CODEX_OAUTH_GET_STATUS, () =>
+    wrap(async (): Promise<CodexOAuthStatusPayload> => {
+      const status = await auth.getStatus();
+      return { ...status, bridge: { baseUrl: bridge.baseUrl, token: bridge.token } };
+    }),
+  );
+  channels.push(IPC.CODEX_OAUTH_GET_STATUS);
+
+  ipcMain.handle(IPC.CODEX_OAUTH_BEGIN_LOGIN, () => wrap(() => auth.login()));
+  channels.push(IPC.CODEX_OAUTH_BEGIN_LOGIN);
+
+  ipcMain.handle(IPC.CODEX_OAUTH_LOGOUT, () => wrap(() => auth.logout()));
+  channels.push(IPC.CODEX_OAUTH_LOGOUT);
+
+  return function dispose() {
+    for (const ch of channels) ipcMain.removeHandler(ch);
+  };
+}

--- a/src/main/orchestrator/vendors/proxy-fetch.test.ts
+++ b/src/main/orchestrator/vendors/proxy-fetch.test.ts
@@ -1,0 +1,57 @@
+// 回归测试：钉住"Codex 的出网请求绝不能落到 Node 的全局 fetch"这条不变量。
+//
+// 背景（真实故障）：Node 的全局 fetch（undici）无视 HTTP_PROXY / 系统代理，一律直连。
+// auth.openai.com / chatgpt.com 在部分地区直连会被回
+//   403 {"code":"unsupported_country_region_territory"}
+// 而 OAuth 的浏览器授权那一步是通的（浏览器走系统代理），于是症状伪装成
+// "OAuth 实现有 bug"，非常费时间。修法是改用 Electron 的 net.fetch（Chromium 网络栈）。
+//
+// 这个文件不测代理本身能不能连通（那取决于跑测试的机器），只测更重要的一件事：
+// 如果哪天有人把某个调用点改回裸 fetch()，测试会失败。
+import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const VENDOR_DIR = __dirname;
+
+describe("Codex 出网请求不得使用 Node 全局 fetch", () => {
+  // 静态检查：这两个文件里不允许出现裸 fetch( 调用。
+  // 它们必须把 fetch 当依赖注入（fetchImpl），生产环境由 proxy-fetch.ts 提供 net.fetch。
+  for (const file of ["codex-oauth-auth.ts", "codex-bridge.ts"]) {
+    it(`${file} 里没有裸 fetch( 调用`, () => {
+      const source = fs.readFileSync(path.join(VENDOR_DIR, file), "utf8");
+      const withoutComments = source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/^\s*\/\/.*$/gm, "");
+      // 允许 fetchImpl(...) / proxyAwareFetch，不允许 fetch(...) 或 globalThis.fetch
+      const bareFetch = withoutComments.match(/(?<![A-Za-z0-9_$.])fetch\s*\(/g);
+      expect(
+        bareFetch,
+        `${file} 出现了裸 fetch( 调用。Node 的全局 fetch 不走代理，` +
+          `auth.openai.com / chatgpt.com 会返回 403 地区封锁。请改用注入的 fetchImpl。`,
+      ).toBeNull();
+      expect(withoutComments).not.toMatch(/globalThis\s*\.\s*fetch/);
+    });
+  }
+
+  it("proxy-fetch 用的是 Electron net.fetch，而不是全局 fetch", async () => {
+    const netFetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.doMock("electron", () => ({ net: { fetch: netFetch } }));
+    // 让全局 fetch 一旦被误用就立刻暴露
+    const globalFetchSpy = vi.fn(async () => new Response("SHOULD NOT BE USED", { status: 500 }));
+    vi.stubGlobal("fetch", globalFetchSpy);
+
+    try {
+      const { proxyAwareFetch } = await import("./proxy-fetch");
+      const res = await proxyAwareFetch("https://auth.openai.com/oauth/token", { method: "POST" });
+
+      expect(await res.text()).toBe("ok");
+      expect(netFetch).toHaveBeenCalledOnce();
+      expect(globalFetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.doUnmock("electron");
+      vi.resetModules();
+    }
+  });
+});

--- a/src/main/orchestrator/vendors/proxy-fetch.ts
+++ b/src/main/orchestrator/vendors/proxy-fetch.ts
@@ -1,0 +1,36 @@
+// 走 Chromium 网络栈（含代理）的 fetch —— 给"必须经过代理才能访问"的厂商用。
+//
+// 为什么不能直接用 Node 的全局 fetch：
+//   Node 的 fetch（undici）完全无视 HTTP_PROXY / HTTPS_PROXY / ALL_PROXY 和操作系统
+//   的代理设置，请求一律直连出去。对 auth.openai.com / chatgpt.com 这类在部分地区
+//   需要代理才能访问的域名，直连拿到的是：
+//     HTTP 403 {"code":"unsupported_country_region_territory"}
+//
+//   而 OAuth 登录流程里"打开浏览器授权"那一步是成功的——浏览器走系统代理。于是现象
+//   变成"浏览器能登录、回来换 token 却 403"，极容易误判成 OAuth 实现写错了。
+//   这不是假想：本文件就是为修这个真实故障而加的（同一进程内实测对比：
+//   net.fetch → 401（正常业务拒绝，说明打通了），全局 fetch → 403 地区封锁）。
+//
+// 为什么用 Electron 的 net.fetch：
+//   - 走 Chromium 网络栈，自动沿用 session 的代理配置（系统代理 / PAC /
+//     --proxy-server 开关），跟浏览器行为一致，用户不需要为本应用单独配一次代理。
+//   - 返回标准 Response，body 是真正的 ReadableStream —— Codex 后端只说 SSE，
+//     必须能流式读，这一点实测确认过。
+//   - 不需要新增依赖。
+//
+// 为什么不用 undici 的 ProxyAgent：
+//   undici 在本仓库只是 devDependency（electron / electron-builder）的传递依赖，
+//   打包后的运行时里并没有这个包，直接 import 会在生产环境炸掉。
+//   （另外 undici 的 ProxyAgent 也不支持 socks5，而用户的代理常是 socks + http 双端口。）
+import { net } from "electron";
+
+/** 只覆盖调用点实际用到的 fetch 形态，方便测试注入假实现。 */
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * 必须在 app ready 之后调用。本仓库的调用点（用户点登录、桥处理请求）都在 ready 之后，
+ * 所以这里不额外加 whenReady 等待——真在 ready 前调用了，Electron 会抛出明确错误，
+ * 比静默排队更容易定位。
+ */
+export const proxyAwareFetch: FetchLike = (url, init) =>
+  net.fetch(url, init as Parameters<typeof net.fetch>[1]);

--- a/src/preload/codex-oauth.ts
+++ b/src/preload/codex-oauth.ts
@@ -1,0 +1,10 @@
+import { contextBridge, ipcRenderer } from "electron";
+import { IPC } from "../shared/ipc-channels";
+
+export function exposeCodexOAuthApi() {
+  contextBridge.exposeInMainWorld("codexOAuth", {
+    getStatus: () => ipcRenderer.invoke(IPC.CODEX_OAUTH_GET_STATUS),
+    beginLogin: () => ipcRenderer.invoke(IPC.CODEX_OAUTH_BEGIN_LOGIN),
+    logout: () => ipcRenderer.invoke(IPC.CODEX_OAUTH_LOGOUT),
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ import type { DocumentIndexProgress } from "../main/rag/document-index-queue";
 import { getLive2DIpcListenerCounts } from "./live2d-listener-diagnostics";
 import { exposeMusicApi } from "./music";
 import { normalizeChatAppearance, type ChatAppearanceSettings } from "../shared/chat-appearance";
+import { exposeCodexOAuthApi } from "./codex-oauth";
 
 const cyreneApi = {
   minimize: () => ipcRenderer.send(IPC.WINDOW_MINIMIZE),
@@ -718,3 +719,4 @@ const gameBotApi = {
 contextBridge.exposeInMainWorld("gameBot", gameBotApi);
 
 exposeMusicApi();
+exposeCodexOAuthApi();

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -136,6 +136,16 @@
               <datalist id="model-input-suggestions"></datalist>
             </label>
 
+            <div class="field field--full" id="codex-oauth-panel" style="display:none">
+              <span>ChatGPT 订阅登录</span>
+              <div class="codex-oauth-row">
+                <button type="button" class="codex-oauth-btn" id="codex-oauth-login-btn">登录 ChatGPT</button>
+                <button type="button" class="codex-oauth-btn" id="codex-oauth-logout-btn" style="display:none">退出登录</button>
+                <span class="form-hint" id="codex-oauth-status">尚未登录</span>
+              </div>
+              <span class="form-hint">用你的 ChatGPT Plus / Pro / Team 订阅跑 Chat 模式，不需要 API Key；登录成功后会自动填好上面的 Base URL / API Key。仅支持 Chat 模式。</span>
+            </div>
+
             <label class="field">
               <span>上下文窗口（Token）</span>
               <input id="context-window-input" type="number" min="4096" step="1" placeholder="256000" autocomplete="off" />

--- a/src/renderer/settings/settings.css
+++ b/src/renderer/settings/settings.css
@@ -2137,6 +2137,36 @@ body {
   color: var(--rb-text-on-pink);
 }
 
+/* Codex（ChatGPT 订阅）OAuth 登录面板 */
+.codex-oauth-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.codex-oauth-btn {
+  flex-shrink: 0;
+  width: auto;
+  padding: 0 14px;
+  height: 36px;
+  border-radius: 12px;
+  color: var(--rb-text-muted);
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 182, 220, 0.14);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+.codex-oauth-btn:hover {
+  border-color: rgba(255, 182, 220, 0.34);
+  background: rgba(255, 255, 255, 0.10);
+  color: var(--rb-text-on-pink);
+}
+.codex-oauth-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 /* 厂商卡片网格 + 官网链接 */
 .preset-row {
   margin-top: 6px;

--- a/src/renderer/settings/settings.ts
+++ b/src/renderer/settings/settings.ts
@@ -389,7 +389,13 @@ interface ModelPreset {
   // 自定义端点的云端/本地变体共用一张可见卡片，但分别持久化配置。
   customEndpointMode?: CustomEndpointMode;
   hiddenInPresetList?: boolean;
+  // 该预设不用 API Key，而是走 ChatGPT 订阅 OAuth 登录（本地桥 + PKCE）。
+  // 为 true 时显示「登录 ChatGPT」面板，登录成功后自动回填 Base URL / API Key。
+  oauthLogin?: boolean;
 }
+
+/** ChatGPT / Codex（订阅）预设的 providerName，OAuth 状态回填时用来判断"当前选中的就是它"。 */
+const CODEX_OAUTH_PROVIDER_NAME = "ChatGPT / Codex（订阅）";
 
 interface GeneralSettings extends ChatAppearanceSettings {
   citaEnabled: boolean;
@@ -617,6 +623,19 @@ const MODEL_PRESETS: ModelPreset[] = [
     websiteUrl: "https://platform.openai.com/",
   },
   {
+    // 用 ChatGPT Plus/Pro/Team 订阅跑 Chat，不用 API Key——本地桥 + PKCE OAuth 登录。
+    // baseUrl/mainModels 都是占位：登录成功后由 codex-oauth-panel 自动回填真实值。
+    providerName: CODEX_OAUTH_PROVIDER_NAME,
+    shortName: "Codex",
+    baseUrl: "http://127.0.0.1:0/v1",
+    // 必须是 Codex 后端 /models 返回的 slug——跟 OpenAI API 的型号名不是一套。
+    // 填 API 那边的名字（gpt-5.1-codex / gpt-5.6 之类）会被回 400。
+    mainModels: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
+    iconUrl: "../icons/providers/openai.svg",
+    websiteUrl: "https://developers.openai.com/codex/auth",
+    oauthLogin: true,
+  },
+  {
     providerName: "Claude（Anthropic）",
     shortName: "Claude",
     baseUrl: "https://api.anthropic.com/v1",
@@ -806,6 +825,89 @@ let editingSchedulerTaskId: string | null = null;
 
 const presetCards = document.getElementById("preset-cards") as HTMLElement;
 const presetWebsiteLink = document.getElementById("preset-website-link") as HTMLAnchorElement;
+
+// ChatGPT / Codex（订阅）OAuth 登录面板。
+// window.codexOAuth.* 由 preload/codex-oauth.ts 通过 contextBridge 暴露；跟 window.music
+// 一样，main/preload 是 esbuild、renderer 是 Vite 打包，两端类型不互通，弱类型化调用。
+interface CodexOAuthIpcResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+}
+interface CodexOAuthStatusPayload {
+  loggedIn: boolean;
+  accountId?: string;
+  bridge: { baseUrl: string; token: string };
+}
+interface CodexOAuthApi {
+  getStatus: () => Promise<CodexOAuthIpcResult<CodexOAuthStatusPayload>>;
+  beginLogin: () => Promise<CodexOAuthIpcResult<{ accountId: string }>>;
+  logout: () => Promise<CodexOAuthIpcResult<void>>;
+}
+function getCodexOAuthApi(): CodexOAuthApi | null {
+  const w = window as unknown as { codexOAuth?: CodexOAuthApi };
+  return w.codexOAuth ?? null;
+}
+
+const codexOAuthPanel = document.getElementById("codex-oauth-panel") as HTMLDivElement | null;
+const codexOAuthLoginBtn = document.getElementById("codex-oauth-login-btn") as HTMLButtonElement | null;
+const codexOAuthLogoutBtn = document.getElementById("codex-oauth-logout-btn") as HTMLButtonElement | null;
+const codexOAuthStatusEl = document.getElementById("codex-oauth-status") as HTMLElement | null;
+
+async function refreshCodexOAuthStatus(): Promise<void> {
+  if (!codexOAuthPanel || codexOAuthPanel.style.display === "none") return;
+  const api = getCodexOAuthApi();
+  if (!api) {
+    if (codexOAuthStatusEl) codexOAuthStatusEl.textContent = "window.codexOAuth 未就绪";
+    return;
+  }
+  const result = await api.getStatus();
+  if (!result.ok || !result.data) {
+    if (codexOAuthStatusEl) codexOAuthStatusEl.textContent = `状态查询失败：${result.error ?? "未知错误"}`;
+    return;
+  }
+  const { loggedIn, accountId, bridge } = result.data;
+  if (codexOAuthStatusEl) {
+    codexOAuthStatusEl.textContent = loggedIn
+      ? `已登录（账户 ${accountId ? accountId.slice(0, 8) : "?"}…）`
+      : "尚未登录";
+  }
+  if (codexOAuthLogoutBtn) codexOAuthLogoutBtn.style.display = loggedIn ? "" : "none";
+  if (codexOAuthLoginBtn) codexOAuthLoginBtn.textContent = loggedIn ? "重新登录" : "登录 ChatGPT";
+  // 只有当前选中的确实是 Codex 预设时才回填，避免切到别的厂商后被悄悄覆盖。
+  if (loggedIn && activeProvider === CODEX_OAUTH_PROVIDER_NAME) {
+    baseUrlInput.value = bridge.baseUrl;
+    apiKeyInput.value = bridge.token;
+  }
+}
+
+codexOAuthLoginBtn?.addEventListener("click", () => {
+  void (async () => {
+    const api = getCodexOAuthApi();
+    if (!api || !codexOAuthLoginBtn) return;
+    codexOAuthLoginBtn.disabled = true;
+    if (codexOAuthStatusEl) codexOAuthStatusEl.textContent = "正在打开浏览器登录…";
+    try {
+      const result = await api.beginLogin();
+      if (!result.ok) {
+        if (codexOAuthStatusEl) codexOAuthStatusEl.textContent = `登录失败：${result.error ?? "未知错误"}`;
+        return;
+      }
+      await refreshCodexOAuthStatus();
+    } finally {
+      codexOAuthLoginBtn.disabled = false;
+    }
+  })();
+});
+
+codexOAuthLogoutBtn?.addEventListener("click", () => {
+  void (async () => {
+    const api = getCodexOAuthApi();
+    if (!api) return;
+    await api.logout();
+    await refreshCodexOAuthStatus();
+  })();
+});
 // 模式按钮已删除——baseUrl 永远可改、模型名永远可手填（datalist 出预设建议）
 // provider 不再暴露给用户（从预设内部拿，保证 capabilities 匹配不出错）。
 // 用户看到的是"昵称"框——给模型起自定义名字，状态栏"正在喂养"显示它。
@@ -1508,6 +1610,17 @@ function applyPreset(
     presetWebsiteLink.style.display = "";
   } else {
     presetWebsiteLink.style.display = "none";
+  }
+
+  // ChatGPT / Codex（订阅）面板：只有选中该预设才显示；显示时立刻拉一次登录状态
+  // （登录过就自动回填 Base URL / API Key，见 refreshCodexOAuthStatus）。
+  if (codexOAuthPanel) {
+    if (preset.oauthLogin) {
+      codexOAuthPanel.style.display = "";
+      void refreshCodexOAuthStatus();
+    } else {
+      codexOAuthPanel.style.display = "none";
+    }
   }
 
   activeProvider = preset.providerName;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -347,5 +347,10 @@ export const IPC = {
 
   // TODO 卡片：初始加载当前状态（常驻需求）
   TODOS_GET_CURRENT: "todos:get-current",
+
+  // ChatGPT / Codex 订阅 OAuth（本机桥 + PKCE 登录）
+  CODEX_OAUTH_GET_STATUS: "codex-oauth:get-status",
+  CODEX_OAUTH_BEGIN_LOGIN: "codex-oauth:begin-login",
+  CODEX_OAUTH_LOGOUT: "codex-oauth:logout",
 } as const;
 

--- a/src/shared/logger-tags.ts
+++ b/src/shared/logger-tags.ts
@@ -25,6 +25,7 @@ export const LogTag = {
   Reranker: "Reranker",
   InboundServer: "InboundServer",
   Channels: "Channels",
+  CodexOAuth: "CodexOAuth",
   Feishu: "Feishu",
   Wechat: "Wechat",
   StickerEmbed: "StickerEmbed",


### PR DESCRIPTION
Closes #25

用 ChatGPT Plus / Pro / Team 订阅跑 Chat 模式，不需要 API Key。

> **关于 #25 的覆盖范围**：issue 里提到 GPT 和 Claude 两条路，本 PR 只实现 **GPT / Codex** 这半边。Claude Agent SDK 那半边在另一条分支（`feat/claude-agent-sdk-chat`）上，尚未合入 master。如果希望 #25 等 Claude 那半边一起合了再关，把上面的 `Closes` 改成 `Part of` 即可。

## 做法

走 Codex CLI 那套 **OAuth 2.0 + PKCE**：应用自己起登录流程、自己拿 token、自己存。**不读 `~/.codex/auth.json`** —— 跟 Codex CLI 抢同一个 refresh token 会在刷新时互相把对方顶下线（provider 刷新时会轮换 refresh token 并作废旧的）。

模型请求这一侧，思路跟已有的 `claude-code-bridge` 一致：main 进程起一个只绑 `127.0.0.1` 的最小 HTTP 服务，**对外说 OpenAI Chat Completions 协议**（`POST /v1/chat/completions`），**对内翻译成 Responses API** 打给 `chatgpt.com/backend-api/codex/responses`。

好处是 `openai-adapter` / `chat-loop` / `capabilities` **一行都不用改** —— 新厂商在调度层眼里只是「baseUrl 恰好指向本机」的普通 OpenAI 兼容厂商。

```
设置面板「登录 ChatGPT」
      → PKCE 授权（系统浏览器）→ localhost:1455 回调 → 换 token → 加密落盘

Chat 请求
      → chat-loop → OpenAICompatAdapter → 本机桥 → Codex Responses API
```

## 边界：只支持 Chat 模式

Work 模式（CITA → Action Gate → Native FC）要求厂商侧提供 tools + structured output；把 Cyrene 的工具协议翻译到 Responses API 的 function-tool 格式再对回来是另一块工作，本 PR 没做。请求里带 `tools` / `tool_choice` 时桥**直接回 400 并说明该换哪个厂商**，而不是静默返回一个错的结果。

这是设计边界，不是未完成项。

## 几个踩过坑、值得记下来的点

**1. 出网必须走 Electron 的 `net.fetch`，不能用 Node 全局 `fetch`**

Node 的 undici 完全无视 `HTTP_PROXY` / 系统代理，请求一律直连。`auth.openai.com` 在部分地区直连会回 `403 unsupported_country_region_territory`，而登录流程里「打开浏览器授权」那步却是通的（浏览器走系统代理）—— 症状伪装成「OAuth 实现有 bug」，很费时间。

`proxy-fetch.ts` 里写清了原委，并有测试钉住「不许退回裸 `fetch(`」。不用 undici 的 `ProxyAgent` 是因为 undici 在本仓库只是 devDependency 的传递依赖，打包后运行时并没有这个包。

**2. SSE 正文有三个来源，只读终结事件的 `output` 会拿到空字符串**

实测 `gpt-5.6-sol` 的 `response.completed` 里 `output` 是**空数组**，正文只出现在中途的 `response.output_text.delta` 和 `response.output_item.done`。按 `output` → `item` → `delta` 三级兜底。

**3. 上游 error 事件的原文必须透出来**

早先的实现收了 error 内容却从不使用（只要流里出现过 `response` 对象，报错路径就走不到），真实原因被自造的「没有返回任何文本」盖掉。已修，并有测试禁止那句话回归。

**4. 上游会间歇性过载**

Codex 后端会在 SSE 里回 `Our servers are currently overloaded`，**跟请求内容无关**（同一请求重发即可成功）。这类临时故障自动重试，但同时受**重试次数**和 **9 秒总预算**双重约束 —— 测试连接只有 15 秒预算，重试把自己拖到超时比老实报错更难排查。

**5. 模型名是另一套命名**

必须用 Codex `/models` 返回的 slug（`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini`）。填 OpenAI API 那边的名字（如 `gpt-5.1-codex`）会被回 `400 not supported when using Codex with a ChatGPT account`。

**6. token 落盘**

复用 `channels/settings-store` 的三级方案：safeStorage（OS 钥匙串）→ 机器指纹混淆 → 明文兜底。**不进 `model-settings.json`** 那份明文配置。

## 测试

`199 个文件 / 1626 个用例` 全绿，`tsc` 无错。

- **auth 侧**：PKCE 参数形状与 `state` 校验（真绑 1455 端口跑完整登录流程）、`accountId` 的 JWT claim 三级回退、刷新加锁（并发只刷一次）、加密落盘 round-trip（safeStorage 可用 / 不可用两条分支）
- **桥侧**：带 `tools` 必须 400、bridge token 不对必须 401、未登录必须 401、上游 error 原文必须透出、临时过载「重试后成功」与「重试后放弃」两条路径、以及**正常回复的形状必须能被真实的 `OpenAICompatAdapter.parseResponse` 解析**（防两边形状漂移）
- **代理**：静态检查钉住两个模块不许出现裸 `fetch(`。该测试做过反向验证 —— 把调用点改回裸 `fetch` 后它确实会失败，不是空跑

## 人工验证

在真实 ChatGPT 订阅账号上跑通：浏览器授权 → 自动回填 Base URL / API Key → 测试连接返回真实文本 → Chat 正常对话。

> **使用提醒**：`gpt-5.6-sol` 是推理模型，一次回复约 **7～13 秒**，不是卡死。另外 Codex 后端目前确实会间歇性过载，失败时错误信息会明确说明是上游容量问题而非配置问题，重试一般即可成功。

## 已知未覆盖

- Work 模式（见上文「边界」一节）
- 视觉输入：桥把消息压成纯文本 `input_text` / `output_text`，图片走不过去
- 流式：Chat 模式当前走非流式路径，桥对 `stream: true` 直接回 400
- 同仓其它厂商（如 `ChatGPT（OpenAI）` / `Claude（Anthropic）` 的 API Key 路径）仍走 `chat-loop` 里的 Node 全局 `fetch`，在需要代理的网络环境下会遇到同样的 403。那是所有厂商共用的路径，本 PR 未改动，可另开一个 PR 处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vTy1HtneLVsHWkhn1Z3tu
