### PR TITLE
fix: resolve production renderer paths from app root

### DIFF
--- a/src/main/startup/create-main-window.ts
+++ b/src/main/startup/create-main-window.ts
@@ -85,7 +85,7 @@ export function createMainWindow(ctx: CreateMainWindowContext): BrowserWindow {
   if (ctx.isDev) {
     win.loadURL("http://localhost:5173");
   } else {
-    win.loadFile(path.join(__dirname, "..", "..", "renderer", "index.html"));
+    win.loadFile(path.join(app.getAppPath(), "dist", "renderer", "index.html"));
   }
 
   if (!ctx.isDev) {

--- a/src/main/windows/create-aux-windows.ts
+++ b/src/main/windows/create-aux-windows.ts
@@ -68,7 +68,7 @@ export function createReactChatWindow(sessionId?: string): void {
 
   // search 字段必须含前导 "?"（Electron url.format() 要求）
   const search = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : undefined;
-  const indexPath = path.join(__dirname, "..", "..", "renderer", "react", "index.html");
+  const indexPath = path.join(app.getAppPath(), "dist", "renderer", "react", "index.html");
 
   if (isDev) {
     void window
@@ -141,7 +141,7 @@ export function createSidebarWindow(): void {
     window.loadURL("http://localhost:5173/sidebar/");
   } else {
     window.loadFile(
-      path.join(__dirname, "..", "..", "renderer", "sidebar", "index.html")
+      path.join(app.getAppPath(), "dist", "renderer", "sidebar", "index.html")
     );
   }
 
@@ -192,7 +192,7 @@ export function createTasksWindow(): void {
     window.loadURL("http://localhost:5173/tasks/");
   } else {
     window.loadFile(
-      path.join(__dirname, "..", "..", "renderer", "tasks", "index.html")
+      path.join(app.getAppPath(), "dist", "renderer", "tasks", "index.html")
     );
   }
 
@@ -254,7 +254,7 @@ export function createSettingsWindow(section?: string): void {
     window.loadURL("http://localhost:5173/settings/" + hash);
   } else {
     window.loadFile(
-      path.join(__dirname, "..", "..", "renderer", "settings", "index.html"),
+      path.join(app.getAppPath(), "dist", "renderer", "settings", "index.html"),
       { hash: section || "" }
     );
   }
@@ -317,7 +317,7 @@ export async function createStickerManagerWindow(): Promise<{ ok: boolean; error
       await window.loadURL("http://localhost:5173/sticker-manager/");
     } else {
       await window.loadFile(
-        path.join(__dirname, "..", "..", "renderer", "sticker-manager", "index.html")
+        path.join(app.getAppPath(), "dist", "renderer", "sticker-manager", "index.html")
       );
     }
   } catch (error) {
@@ -384,7 +384,7 @@ export function createCallWindow(): void {
   if (isDev) {
     window.loadURL("http://localhost:5173/call/");
   } else {
-    window.loadFile(path.join(__dirname, "..", "..", "renderer", "call", "index.html"));
+    window.loadFile(path.join(app.getAppPath(), "dist", "renderer", "call", "index.html"));
   }
 
   window.once("ready-to-show", () => {


### PR DESCRIPTION
## Summary

Fix production renderer paths used by the main and auxiliary Electron windows.

## Problem

After building and launching the application with `cyrene run`, Electron attempts to load renderer pages from:

`dist/main/renderer/...`

However, Vite outputs these files to:

`dist/renderer/...`

This causes `ERR_FILE_NOT_FOUND`, leaving only the tray icon available.

## Fix

Resolve renderer files from `app.getAppPath()/dist/renderer` instead of relying on paths relative to the compiled module's `__dirname`.

This also avoids depending on the nesting depth of files under `dist/main/main`.

## Verification

- `npm run build:main`
- `npm run build`
- Launched the application using `cyrene run`
- Confirmed the main and auxiliary renderer pages load without `ERR_FILE_NOT_FOUND`