### PR TITLE
新增插件系统：适配新版生命周期并支持安全卸载

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,10 @@ jobs:
           if (-not $files) { Write-Host "No root test files found"; exit 0 }
           npx vitest run --reporter=verbose --maxWorkers=1 $files
 
+      - name: Test src/plugins
+        if: success() || failure()
+        run: npx vitest run --reporter=verbose --maxWorkers=1 src/plugins
+
       - name: Test src/renderer
         if: success() || failure()
         run: npx vitest run --reporter=verbose --maxWorkers=1 src/renderer

--- a/docs/plugins/plugin-authoring.md
+++ b/docs/plugins/plugin-authoring.md
@@ -1,77 +1,119 @@
-# Cyrene 插件开发规范
+# Cyrene Runtime Plugin API v1
 
-本文描述 Cyrene-Agent 插件系统 v1。插件以“目录 + `manifest.json` + JavaScript 入口文件”交付，应用启动时扫描，用户可在设置页的“功能插件”中启停。
+本文描述 Cyrene-Agent 的可信本地运行时插件系统。插件以“目录 + `manifest.json` +
+JavaScript 入口”交付，可注册工具、插件私有 IPC、渠道 adapter，并按声明使用 Cyrene
+提供的 LLM 服务。
 
-> 安全提示：插件入口运行在 Electron 主进程中，拥有与 Cyrene 相同的本机权限。只安装和启用你信任的插件。
+## 安全与信任边界
 
-## 目录与扫描位置
+> 插件入口在 Electron Main Process 中执行，拥有与 Cyrene 相同的本机权限。它不是
+> 沙箱、Web 扩展或权限隔离进程。只安装你能审查且信任其来源的插件。
 
-用户插件目录：
+`manifest.deps` 表示“希望 Cyrene 注入哪些主程序服务”，不是操作系统权限清单。
+插件代码仍可直接使用 Node.js 能力，因此：
+
+- 用户插件首次发现后一律保持停用，即使 manifest 声明 `defaultEnabled: true`。
+- 设置页显示插件来源、实际路径、API 版本、运行状态和最后一次错误。
+- 只有用户明确点击“启用”后，用户插件入口才会被加载。
+- 内置插件可使用 `defaultEnabled`，因为它与应用一起构建和发布。
+
+## 目录与扫描来源
+
+用户插件：
 
 ```text
-userData/plugins/<id>/
+userData/plugins/<plugin-id>/
   manifest.json
   index.cjs
 ```
 
-内置插件由 `src/plugins/<id>/` 编译到 `dist/main/plugins/<id>/`。运行时先扫描内置目录，再扫描用户目录；重复 id 保留先扫描到的插件。扫描只检查根目录下的一级子目录。
+内置插件：
 
-插件数据不会写回代码目录，而是保存在 `userData/plugin-data/<id>/`。
+```text
+src/plugins/<plugin-id>/
+  manifest.json
+  index.ts
+```
+
+内置插件由构建流程复制/编译到 `dist/main/plugins`。插件私有数据位于：
+
+```text
+userData/plugin-data/<plugin-id>/
+```
+
+扫描只读取每个根目录的一级子目录。单个无效插件、不可读目录或错误 manifest 会记录为
+扫描问题并展示在设置页，不会阻止 Cyrene 启动。重复 ID 保留先扫描到的插件；内置目录
+优先于用户目录，因此用户插件不能覆盖内置插件。
 
 ## manifest.json
 
-| 字段 | 类型 | 必填 | 说明 |
-|---|---|---|---|
-| `id` | string | 是 | 唯一 id，须匹配 `^[a-z0-9]+(-[a-z0-9]+)*$` |
-| `name` | string | 是 | 设置页显示名 |
-| `version` | string | 是 | 插件版本 |
-| `description` | string | 是 | 简短说明 |
-| `author` | string | 是 | 作者 |
-| `entry` | string | 是 | 插件目录内的裸文件名，支持 `.cjs`、`.js`、`.mjs` |
-| `defaultEnabled` | boolean | 否 | 初次发现时是否启用，缺省为 `true` |
-| `deps` | string[] | 否 | 主程序能力白名单，v1 支持 `channels`、`llm` |
-
-示例：
+完整示例：
 
 ```json
 {
+  "apiVersion": 1,
   "id": "my-plugin",
   "name": "My Plugin",
   "version": "1.0.0",
   "description": "An example Cyrene plugin",
   "author": "Your Name",
   "entry": "index.cjs",
-  "defaultEnabled": false
+  "defaultEnabled": false,
+  "deps": ["llm"]
 }
 ```
 
-`entry` 不允许包含子目录或 `..`。缺少必填字段、入口不存在或扩展名不受支持时，该目录会被跳过。
+| 字段 | 类型 | 必填 | 规则 |
+|---|---|---|---|
+| `apiVersion` | number | 是 | 当前必须为 `1` |
+| `id` | string | 是 | 匹配 `^[a-z0-9]+(-[a-z0-9]+)*$` |
+| `name` | string | 是 | 非空显示名 |
+| `version` | string | 是 | 严格 SemVer，例如 `1.2.0`、`2.0.0-beta.1` |
+| `description` | string | 是 | 非空简介 |
+| `author` | string | 是 | 非空作者 |
+| `entry` | string | 是 | 插件目录内裸文件名；支持 `.cjs`、`.js`、`.mjs` |
+| `defaultEnabled` | boolean | 否 | 缺省 true，但只对内置插件生效 |
+| `deps` | string[] | 否 | 可选 `channels`、`llm` |
+
+以下情况会拒绝加载：
+
+- 缺少或不兼容的 `apiVersion`；
+- version 不是 SemVer；
+- `deps` 含未知值或不是数组；
+- `defaultEnabled` 不是布尔值；
+- entry 包含子目录、`..`、扩展名不受支持；
+- entry 不存在、不是普通文件，或通过符号链接指向插件目录外。
+
+未知依赖会使 manifest 整体失败，不会静默过滤。这样可以尽早暴露 `lllm` 一类拼写错误。
 
 ## 入口契约
 
-入口必须导出 `register(ctx)`，可以导出 `unregister()` 和 `open()`：
+CommonJS：
 
 ```js
 module.exports = {
-  register(ctx) {
+  async register(ctx) {
     ctx.log("enabled");
   },
-  unregister() {
-    // Close windows, timers, and other plugin-owned resources here.
+  async unregister() {
+    // Close plugin-owned windows, timers and background work.
   },
-  open() {
-    // Optional controlled entry called by the settings UI.
+  async open() {
+    // Optional controlled entry called from Settings.
   },
 };
 ```
 
-ESM 入口可用命名导出或默认导出。启用时调用 `register`；停用和退出时调用 `unregister`，随后框架清理通过 context 注册的资源。
+ESM 可使用默认导出或命名导出。必须提供 `register(ctx)`；`unregister()` 与
+`open()` 可选。
 
-## PluginContext
+## 稳定 Plugin API
+
+插件面向的类型统一定义在 `src/plugins/api.ts`。该文件不导入 `src/main/**` 或
+`src/shared/**`；Cyrene 内部类型只在 context adapter 边界转换。第三方插件不应直接
+导入应用内部模块。
 
 ### 工具
-
-`ctx.registerTool(tool)` 将工具加入主程序的 `ToolRegistry`。工具 id 必须以 `<plugin-id>_` 开头，且不能与现有工具重复。
 
 ```js
 ctx.registerTool({
@@ -79,79 +121,193 @@ ctx.registerTool({
   name: "Hello",
   description: "Return a greeting",
   enabled: true,
-  inputSchema: { type: "object", properties: {}, required: [] },
-  execute: async () => "Hello from my plugin",
+  risk: "safe",
+  effectKind: "read",
+  verificationPolicy: "none",
+  inputSchema: {
+    type: "object",
+    properties: {},
+    required: []
+  },
+  execute: async () => "Hello from my plugin"
 });
 ```
 
-可用 `ctx.unregisterTool(id)` 主动注销；停用插件时框架也会兜底清理。
+工具 ID 必须以 `<plugin-id>_` 开头。Context 会拒绝重复 ID，也拒绝插件注销核心工具或
+其他插件的工具：
+
+```js
+ctx.unregisterTool("my-plugin_hello"); // allowed
+ctx.unregisterTool("read_file");       // rejected
+```
 
 ### IPC
-
-`ctx.registerIpc(channel, handler)` 注册的通道会自动变为 `plugin:<id>:<channel>`：
 
 ```js
 ctx.registerIpc("ping", () => "pong");
 ```
 
-使用 `ctx.unregisterIpc(channel)` 主动注销。
+实际 Electron IPC 名称为 `plugin:<plugin-id>:ping`。channel 只允许字母、数字、
+`.`、`_`、`-`，长度不超过 64。插件只能注销当前 context 注册过的 IPC。
 
 ### 私有存储
 
 ```js
 ctx.storage.set("config", { endpoint: "https://example.com" });
 const config = ctx.storage.get("config");
-ctx.storage.rootDir();
 ```
 
-每个 key 对应一个 JSON 文件。key 须匹配 `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`，写入使用临时文件加 rename。
+每个 key 对应一个 JSON 文件。key 必须匹配
+`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`。写入使用临时文件和 rename，避免进程崩溃留下
+半份 JSON。
 
-### 主程序依赖
+### Channels
 
-插件不得直接导入 `src/main/**` 或 `src/shared/**` 的内部模块。需要能力时，在 manifest 的 `deps` 中声明：
+渠道注册必须通过 Context：
 
-- `channels`：提供 `ctx.deps.channels.channelManager` 的 `register`、`unregister`、`startOne`。
-- `llm`：提供 `ctx.deps.llm.generateText(messages)`，使用当前主聊天模型执行一次非流式文本请求。
+```js
+await ctx.registerChannelAdapter(adapter);
+await ctx.unregisterChannelAdapter(adapter.id);
+```
 
-未声明的依赖不会注入。渠道 adapter id 不能覆盖已注册渠道，并且仍须属于主程序的 `ChannelId`；新增渠道类型需要先扩展主程序类型定义。
+Context 会跟踪 adapter 所有权并在插件停用时兜底清理。插件不能注销内置渠道或其他插件
+注册的渠道。
 
-## 生命周期
+当 manifest 声明 `"deps": ["channels"]` 时，仅额外提供只读发现能力：
+
+```js
+ctx.deps.channels.has("feishu");
+```
+
+内置 adapter 会在插件激活前完成注册。ChannelManager 对重复 ID 直接报错，不再覆盖已经
+启动的实例。
+
+### LLM
+
+manifest：
+
+```json
+{
+  "deps": ["llm"]
+}
+```
+
+调用：
+
+```js
+const text = await ctx.deps.llm.generateText(
+  [{ role: "user", content: "Summarize this text" }],
+  {
+    purpose: "summary",
+    maxTokens: 1024,
+    timeoutMs: 30000,
+    signal: abortController.signal
+  }
+);
+```
+
+LLM 请求使用当前默认模型档案，并统一经过 Cyrene 的 `LlmClient`、后台 FIFO 队列、
+限流重试、timeout、取消、token usage 与请求日志。限制：
+
+- `maxTokens`：1-8192，缺省 1024；
+- `timeoutMs`：1000-300000；缺省使用聊天超时并封顶 120 秒；
+- `purpose`：只用于诊断标签，不影响模型选择。
+
+## 生命周期和状态
 
 ```text
-应用启动
-  -> 扫描并校验 manifest
-  -> 读取 app-settings.json 中的插件开关
-  -> 加载已启用插件并调用 register(ctx)
+scan
+  -> disabled
+  -> starting
+  -> running
+  -> stopping
+  -> disabled
 
-设置页切换
-  -> 启用：加载入口并 register(ctx)
-  -> 停用：unregister()，然后清理工具、IPC 和渠道 adapter
-
-应用退出
-  -> stop() 清理全部已启用插件
+starting --error--> failed
+failed --retry--> starting
 ```
 
-启停状态保存在通用设置的 `plugins` 映射中。插件在运行中启停无需重启；新增或删除插件目录后需要重启以重新扫描。
+设置页区分：
 
-## 带 UI 的插件
+- `configuredEnabled`：用户希望插件启用；
+- `status`：`disabled | starting | running | stopping | failed`；
+- `error`：最后一次激活失败原因。
 
-v1 不提供动态 renderer bundle。插件可导出 `open()` 作为受控入口；设置页只会为已启用且实现 `open()` 的插件显示“打开”按钮。内置插件如需完整渲染页面，仍需在主项目构建配置中显式加入页面入口。
+因此“配置为启用但 register 失败”不会伪装成普通停用。用户可以重试，也可以关闭 desired
+state，避免每次启动重复尝试。
 
-插件应在 `unregister()` 中关闭自己创建的窗口、定时器和后台任务。
+所有 enable、disable、open、rescan、stop 操作经过同一生命周期队列串行执行，避免并发
+点击或多个 renderer 请求造成重复注册和 context 泄漏。
+
+## 刷新、更新与模块缓存
+
+设置页“刷新插件”会：
+
+1. 重新扫描内置和用户目录；
+2. 停止并移除已删除插件；
+3. 清理活动插件资源；
+4. 清除该插件目录下的 CommonJS `require.cache`；
+5. 使用 cache-busting URL 重新导入 ESM 入口；
+6. 重新激活仍配置为启用的插件；
+7. 展示 manifest、重复 ID 和目录读取问题。
+
+活动插件会在手动刷新时重新加载，即使 manifest 没变。新增用户插件仍保持停用。
+
+## 应用退出
+
+插件清理加入应用 shutdown latch。Cyrene 会等待：
+
+1. 插件 `unregister()`；
+2. Context 工具、IPC、渠道资源回收；
+3. 内置 Channels、截图服务、LSP 和 Git 服务关闭；
+4. 音乐子系统关闭。
+
+总等待上限为 8 秒，超时后才强制退出。插件仍应让 `unregister()` 有界且可重复调用。
+
+## 从最初 v1 草案迁移
+
+旧 manifest：
+
+```json
+{
+  "id": "my-plugin",
+  "version": "1.0.0"
+}
+```
+
+必须增加：
+
+```json
+{
+  "apiVersion": 1
+}
+```
+
+其他行为变化：
+
+- 用户插件不再自动启用；
+- `deps.channels.channelManager` 已移除，改用 Context 注册方法和
+  `deps.channels.has()`；
+- 非法 deps 不再过滤，而是拒绝 manifest；
+- version 必须为 SemVer；
+- 注销非本插件资源会抛错；
+- 插件列表 IPC 返回 `{ plugins, issues }`，不再只返回数组。
 
 ## 验证
 
 ```bash
-npx vitest run src/plugins
-npm run build:main
+npx vitest run src/plugins src/main/plugin-llm.test.ts src/main/channels/manager.test.ts
+npm run build
 ```
 
-建议逐项确认：
+建议人工验收：
 
-1. 设置页能显示插件并持久化开关。
-2. 工具和 IPC 在启用后出现、停用后消失。
-3. `register()` 失败时已注册资源会回滚。
-4. 插件数据只写入 `userData/plugin-data/<id>/`。
-5. 带 `open()` 的插件只能在启用状态打开。
+1. 新用户插件出现但不会自动执行；
+2. 启用/停用后工具、IPC 和 adapter 对称增减；
+3. register 失败后设置页显示 `failed` 和具体错误；
+4. 修改入口后点击刷新，运行行为切换到新版本；
+5. 删除插件目录后刷新，插件资源和列表项消失；
+6. 重复使用 `feishu` 等内置渠道 ID 时启用失败，内置渠道仍正常；
+7. 退出时异步 `unregister()` 能在 shutdown latch 内完成。
 
-仓库内的 `src/plugins/demo/` 是一个默认关闭的最小内置示例。
+仓库内 `src/plugins/demo/` 是默认停用的最小内置示例。

--- a/docs/plugins/plugin-authoring.md
+++ b/docs/plugins/plugin-authoring.md
@@ -1,0 +1,157 @@
+# Cyrene 插件开发规范
+
+本文描述 Cyrene-Agent 插件系统 v1。插件以“目录 + `manifest.json` + JavaScript 入口文件”交付，应用启动时扫描，用户可在设置页的“功能插件”中启停。
+
+> 安全提示：插件入口运行在 Electron 主进程中，拥有与 Cyrene 相同的本机权限。只安装和启用你信任的插件。
+
+## 目录与扫描位置
+
+用户插件目录：
+
+```text
+userData/plugins/<id>/
+  manifest.json
+  index.cjs
+```
+
+内置插件由 `src/plugins/<id>/` 编译到 `dist/main/plugins/<id>/`。运行时先扫描内置目录，再扫描用户目录；重复 id 保留先扫描到的插件。扫描只检查根目录下的一级子目录。
+
+插件数据不会写回代码目录，而是保存在 `userData/plugin-data/<id>/`。
+
+## manifest.json
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `id` | string | 是 | 唯一 id，须匹配 `^[a-z0-9]+(-[a-z0-9]+)*$` |
+| `name` | string | 是 | 设置页显示名 |
+| `version` | string | 是 | 插件版本 |
+| `description` | string | 是 | 简短说明 |
+| `author` | string | 是 | 作者 |
+| `entry` | string | 是 | 插件目录内的裸文件名，支持 `.cjs`、`.js`、`.mjs` |
+| `defaultEnabled` | boolean | 否 | 初次发现时是否启用，缺省为 `true` |
+| `deps` | string[] | 否 | 主程序能力白名单，v1 支持 `channels`、`llm` |
+
+示例：
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "description": "An example Cyrene plugin",
+  "author": "Your Name",
+  "entry": "index.cjs",
+  "defaultEnabled": false
+}
+```
+
+`entry` 不允许包含子目录或 `..`。缺少必填字段、入口不存在或扩展名不受支持时，该目录会被跳过。
+
+## 入口契约
+
+入口必须导出 `register(ctx)`，可以导出 `unregister()` 和 `open()`：
+
+```js
+module.exports = {
+  register(ctx) {
+    ctx.log("enabled");
+  },
+  unregister() {
+    // Close windows, timers, and other plugin-owned resources here.
+  },
+  open() {
+    // Optional controlled entry called by the settings UI.
+  },
+};
+```
+
+ESM 入口可用命名导出或默认导出。启用时调用 `register`；停用和退出时调用 `unregister`，随后框架清理通过 context 注册的资源。
+
+## PluginContext
+
+### 工具
+
+`ctx.registerTool(tool)` 将工具加入主程序的 `ToolRegistry`。工具 id 必须以 `<plugin-id>_` 开头，且不能与现有工具重复。
+
+```js
+ctx.registerTool({
+  id: "my-plugin_hello",
+  name: "Hello",
+  description: "Return a greeting",
+  enabled: true,
+  inputSchema: { type: "object", properties: {}, required: [] },
+  execute: async () => "Hello from my plugin",
+});
+```
+
+可用 `ctx.unregisterTool(id)` 主动注销；停用插件时框架也会兜底清理。
+
+### IPC
+
+`ctx.registerIpc(channel, handler)` 注册的通道会自动变为 `plugin:<id>:<channel>`：
+
+```js
+ctx.registerIpc("ping", () => "pong");
+```
+
+使用 `ctx.unregisterIpc(channel)` 主动注销。
+
+### 私有存储
+
+```js
+ctx.storage.set("config", { endpoint: "https://example.com" });
+const config = ctx.storage.get("config");
+ctx.storage.rootDir();
+```
+
+每个 key 对应一个 JSON 文件。key 须匹配 `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`，写入使用临时文件加 rename。
+
+### 主程序依赖
+
+插件不得直接导入 `src/main/**` 或 `src/shared/**` 的内部模块。需要能力时，在 manifest 的 `deps` 中声明：
+
+- `channels`：提供 `ctx.deps.channels.channelManager` 的 `register`、`unregister`、`startOne`。
+- `llm`：提供 `ctx.deps.llm.generateText(messages)`，使用当前主聊天模型执行一次非流式文本请求。
+
+未声明的依赖不会注入。渠道 adapter id 不能覆盖已注册渠道，并且仍须属于主程序的 `ChannelId`；新增渠道类型需要先扩展主程序类型定义。
+
+## 生命周期
+
+```text
+应用启动
+  -> 扫描并校验 manifest
+  -> 读取 app-settings.json 中的插件开关
+  -> 加载已启用插件并调用 register(ctx)
+
+设置页切换
+  -> 启用：加载入口并 register(ctx)
+  -> 停用：unregister()，然后清理工具、IPC 和渠道 adapter
+
+应用退出
+  -> stop() 清理全部已启用插件
+```
+
+启停状态保存在通用设置的 `plugins` 映射中。插件在运行中启停无需重启；新增或删除插件目录后需要重启以重新扫描。
+
+## 带 UI 的插件
+
+v1 不提供动态 renderer bundle。插件可导出 `open()` 作为受控入口；设置页只会为已启用且实现 `open()` 的插件显示“打开”按钮。内置插件如需完整渲染页面，仍需在主项目构建配置中显式加入页面入口。
+
+插件应在 `unregister()` 中关闭自己创建的窗口、定时器和后台任务。
+
+## 验证
+
+```bash
+npx vitest run src/plugins
+npm run build:main
+```
+
+建议逐项确认：
+
+1. 设置页能显示插件并持久化开关。
+2. 工具和 IPC 在启用后出现、停用后消失。
+3. `register()` 失败时已注册资源会回滚。
+4. 插件数据只写入 `userData/plugin-data/<id>/`。
+5. 带 `open()` 的插件只能在启用状态打开。
+
+仓库内的 `src/plugins/demo/` 是一个默认关闭的最小内置示例。

--- a/docs/plugins/plugin-authoring.md
+++ b/docs/plugins/plugin-authoring.md
@@ -27,6 +27,15 @@ userData/plugins/<plugin-id>/
   index.cjs
 ```
 
+打包版 Windows 默认对应：
+
+```text
+%APPDATA%\live2d-cyrene\plugins\<plugin-id>\
+```
+
+运行时始终以 Electron `app.getPath("userData")` 的实际返回值为准；如果开发者或测试显式
+覆盖了 `userData`，插件根目录也会随之变化。
+
 内置插件：
 
 ```text
@@ -236,8 +245,8 @@ failed --retry--> starting
 因此“配置为启用但 register 失败”不会伪装成普通停用。用户可以重试，也可以关闭 desired
 state，避免每次启动重复尝试。
 
-所有 enable、disable、open、rescan、stop 操作经过同一生命周期队列串行执行，避免并发
-点击或多个 renderer 请求造成重复注册和 context 泄漏。
+所有 enable、disable、open、rescan、uninstall、stop 操作经过同一生命周期队列串行执行，
+避免并发点击或多个 renderer 请求造成重复注册和 context 泄漏。
 
 ## 刷新、更新与模块缓存
 
@@ -253,16 +262,32 @@ state，避免每次启动重复尝试。
 
 活动插件会在手动刷新时重新加载，即使 manifest 没变。新增用户插件仍保持停用。
 
+## 卸载用户插件
+
+设置页只对用户插件显示“卸载”。卸载事务按以下顺序执行：
+
+1. 确认目标来自用户插件扫描源；内置插件拒绝卸载；
+2. 确认目标是用户插件根目录中的一级普通目录，并通过真实路径再次验证没有越界；
+3. 停止插件并释放工具、IPC、渠道适配器等运行资源；
+4. 清除该插件的持久启停记录，确保删除失败时也不会在下次扫描自动重启；
+5. 清理模块缓存并递归删除插件程序目录；
+6. 执行一次不重启其他活动插件的增量重扫。
+
+卸载只删除 `userData/plugins/<plugin-id>/` 中的插件程序。默认保留
+`userData/plugin-data/<plugin-id>/` 中的插件私有数据，避免卸载误删用户内容；如需彻底清除，
+应由用户另行确认后手动删除对应数据目录。
+
 ## 应用退出
 
-插件清理加入应用 shutdown latch。Cyrene 会等待：
+插件清理加入新版应用退出协调器的固定阶段。Cyrene 会依次等待：
 
 1. 插件 `unregister()`；
 2. Context 工具、IPC、渠道资源回收；
-3. 内置 Channels、截图服务、LSP 和 Git 服务关闭；
-4. 音乐子系统关闭。
+3. 插件在 `stopActiveWork` 阶段完成后，再在 `stopExternalConsumers` 阶段关闭内置 Channels；
+4. 截图服务、LSP、Git 与音乐等本地资源关闭。
 
-总等待上限为 8 秒，超时后才强制退出。插件仍应让 `unregister()` 有界且可重复调用。
+受控退出总等待上限为 10 秒，超时后中止继续等待并执行最终退出动作。插件仍应让
+`unregister()` 有界且可重复调用。
 
 ## 从最初 v1 草案迁移
 
@@ -306,8 +331,8 @@ npm run build
 2. 启用/停用后工具、IPC 和 adapter 对称增减；
 3. register 失败后设置页显示 `failed` 和具体错误；
 4. 修改入口后点击刷新，运行行为切换到新版本；
-5. 删除插件目录后刷新，插件资源和列表项消失；
+5. 用户插件点击卸载并确认后，程序目录、资源和启停记录消失，私有数据目录保留；
 6. 重复使用 `feishu` 等内置渠道 ID 时启用失败，内置渠道仍正常；
-7. 退出时异步 `unregister()` 能在 shutdown latch 内完成。
+7. 退出时异步 `unregister()` 在退出协调器内完成，并严格早于内置 Channels 关闭。
 
 仓库内 `src/plugins/demo/` 是默认停用的最小内置示例。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cyrene": "./dist/cli/index.js"
   },
   "scripts": {
-    "build:main": "tsc -p tsconfig.main.json",
+    "build:main": "node -e \"require('fs').rmSync('dist/main/plugins',{recursive:true,force:true})\" && tsc -p tsconfig.main.json && node -e \"const fs=require('fs');fs.cpSync('src/plugins','dist/main/plugins',{recursive:true,filter:s=>fs.statSync(s).isDirectory()||s.endsWith('manifest.json')})\"",
     "build:preload": "tsc -p tsconfig.preload.json",
     "build:renderer": "vite build",
     "build:cli": "node scripts/build/cli.mjs",

--- a/src/main/application/application.test.ts
+++ b/src/main/application/application.test.ts
@@ -24,6 +24,7 @@ function makeCore(): CoreResult {
     runtime: {} as never,
     services: {} as never,
     channels: {} as never,
+    plugins: {} as never,
     scheduler: {} as never,
   };
 }

--- a/src/main/application/background.test.ts
+++ b/src/main/application/background.test.ts
@@ -9,6 +9,7 @@ function makeCore(): CoreResult {
     runtime: {} as never,
     services: {} as never,
     channels: {} as never,
+    plugins: {} as never,
     scheduler: {} as never,
   };
 }

--- a/src/main/application/core-bootstrap.test.ts
+++ b/src/main/application/core-bootstrap.test.ts
@@ -69,7 +69,16 @@ function makeCoreDeps(calls: string[], overrides: Partial<CoreDependencies> = {}
     registerAllTools: () => { calls.push("tools"); },
     initRag: async () => { calls.push("rag"); },
     createRuntime: () => { calls.push("runtime"); return {} as never; },
-    createChannels: () => ({ initialize: () => { calls.push("channels-initialize"); }, start: vi.fn(async () => { calls.push("channels-start"); }), shutdown: vi.fn(async () => undefined) } as never),
+    createChannels: () => ({
+      initialize: () => { calls.push("channels-initialize"); },
+      adaptersRegistered: Promise.resolve(),
+      start: vi.fn(async () => { calls.push("channels-start"); }),
+      shutdown: vi.fn(async () => undefined),
+    } as never),
+    startPlugins: async () => {
+      calls.push("plugins-start");
+      return { stop: vi.fn(async () => undefined) } as never;
+    },
     createScheduler: () => ({ initialize: () => { calls.push("scheduler-initialize"); }, start: vi.fn(() => { calls.push("scheduler-start"); }), stop: vi.fn() } as never),
     registerCoreIpc: () => { calls.push("register-core-ipc"); },
     loadGeneralSettings: () => ({ petVisible: true, sidebarVisible: false, tasksVisible: false }) as never,
@@ -97,6 +106,8 @@ describe("startCore", () => {
     await startCore(makeCoreDeps(calls));
     expect(calls.indexOf("register-core-ipc")).toBeLessThan(calls.indexOf("chat-load"));
     expect(calls.indexOf("channels-initialize")).toBeLessThan(calls.indexOf("chat-load"));
+    expect(calls.indexOf("channels-initialize")).toBeLessThan(calls.indexOf("plugins-start"));
+    expect(calls.indexOf("plugins-start")).toBeLessThan(calls.indexOf("chat-load"));
     expect(calls).not.toContain("channels-start");
     expect(calls).not.toContain("scheduler-start");
   });

--- a/src/main/application/core-bootstrap.test.ts
+++ b/src/main/application/core-bootstrap.test.ts
@@ -73,11 +73,11 @@ function makeCoreDeps(calls: string[], overrides: Partial<CoreDependencies> = {}
       initialize: () => { calls.push("channels-initialize"); },
       adaptersRegistered: Promise.resolve(),
       start: vi.fn(async () => { calls.push("channels-start"); }),
-      shutdown: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => { calls.push("channels-stop"); }),
     } as never),
     startPlugins: async () => {
       calls.push("plugins-start");
-      return { stop: vi.fn(async () => undefined) } as never;
+      return { stop: vi.fn(async () => { calls.push("plugins-stop"); }) } as never;
     },
     createScheduler: () => ({ initialize: () => { calls.push("scheduler-initialize"); }, start: vi.fn(() => { calls.push("scheduler-start"); }), stop: vi.fn() } as never),
     registerCoreIpc: () => { calls.push("register-core-ipc"); },
@@ -122,6 +122,27 @@ describe("startCore", () => {
     expect(deps.chatLoad).toHaveBeenCalledOnce();
   });
 
+  it("waits for the built-in adapter boundary before starting plugins", async () => {
+    const calls: string[] = [];
+    let releaseAdapters!: () => void;
+    const adaptersRegistered = new Promise<void>((resolve) => { releaseAdapters = resolve; });
+    const deps = makeCoreDeps(calls, {
+      createChannels: () => ({
+        initialize: () => { calls.push("channels-initialize"); },
+        adaptersRegistered,
+        start: vi.fn(async () => undefined),
+        shutdown: vi.fn(async () => undefined),
+      } as never),
+    });
+
+    const starting = startCore(deps);
+    await vi.waitFor(() => expect(calls).toContain("channels-initialize"));
+    expect(calls).not.toContain("plugins-start");
+    releaseAdapters();
+    await starting;
+    expect(calls).toContain("plugins-start");
+  });
+
   it("degrades skills failure and continues startup", async () => {
     const deps = makeCoreDeps([], {
       initSkills: () => { throw new Error("skills broken"); },
@@ -162,5 +183,16 @@ describe("startCore", () => {
     await startCore(deps);
     expect(calls.indexOf("reveal")).toBeLessThan(calls.indexOf("mark-startup-windows"));
     expect(deps.readiness.getPhase()).toBe("core-ready");
+  });
+
+  it("stops plugins before built-in channels during controlled shutdown", async () => {
+    const calls: string[] = [];
+    const deps = makeCoreDeps(calls);
+    await startCore(deps);
+
+    await deps.shutdown.requestControlledShutdown({ reason: "test", finalAction: vi.fn() });
+
+    expect(calls.indexOf("plugins-stop")).toBeGreaterThan(-1);
+    expect(calls.indexOf("plugins-stop")).toBeLessThan(calls.indexOf("channels-stop"));
   });
 });

--- a/src/main/application/core-bootstrap.ts
+++ b/src/main/application/core-bootstrap.ts
@@ -30,6 +30,7 @@ import type { SocialContextService } from "../services/social-context/social-con
 import type { ChannelsSubsystem } from "../channels/bootstrap";
 import type { SchedulerSubsystem } from "../scheduler/bootstrap";
 import type { GeneralSettings } from "../settings/general-settings";
+import type { PluginManager } from "../../plugins/manager";
 
 export interface CoreServices {
   runtimeState: RuntimeStateService;
@@ -51,6 +52,7 @@ export interface CoreResult {
   runtime: AgentRuntime;
   services: CoreServices;
   channels: ChannelsSubsystem;
+  plugins: PluginManager;
   scheduler: SchedulerSubsystem;
 }
 
@@ -77,6 +79,8 @@ export interface CoreDependencies {
   initRag(): Promise<void>;
   createRuntime(services: CoreServices): AgentRuntime;
   createChannels(runtime: AgentRuntime, services: CoreServices): ChannelsSubsystem;
+  /** 必须在内置渠道适配器注册完成后调用。 */
+  startPlugins(services: CoreServices): Promise<PluginManager>;
   createScheduler(runtime: AgentRuntime, services: CoreServices): SchedulerSubsystem;
   registerCoreIpc(input: RegisterCoreIpcInput): void;
   loadGeneralSettings(): GeneralSettings;
@@ -131,9 +135,14 @@ export async function startCore(deps: CoreDependencies): Promise<CoreResult> {
 
   const runtime = deps.createRuntime(services);
 
-  // scheduler/channels：只装配（加载 store、注册 IPC），engine/网络启动在 background 阶段
+  // channels 只装配并同步注册内置 adapter；网络启动仍在 background 阶段。
   const channels = deps.createChannels(runtime, services);
   channels.initialize();
+  await channels.adaptersRegistered;
+
+  // 插件严格晚于内置 adapter id 预留，避免插件抢占 feishu/wechat/qq 等内置 id。
+  const plugins = await deps.startPlugins(services);
+
   const scheduler = deps.createScheduler(runtime, services);
   scheduler.initialize();
 
@@ -163,6 +172,11 @@ export async function startCore(deps: CoreDependencies): Promise<CoreResult> {
   if (generalSettings.tasksVisible) shell.windowManager.createTasksWindow();
 
   // 注册核心资源清理（固定阶段）；scheduler/proactive/更新定时器由 background 注册
+  shutdown.register({
+    id: "plugins",
+    phase: "stopActiveWork",
+    dispose: async () => { await plugins.stop(); },
+  });
   shutdown.register({
     id: "channels",
     phase: "stopExternalConsumers",
@@ -203,5 +217,5 @@ export async function startCore(deps: CoreDependencies): Promise<CoreResult> {
   // 主窗口可激活：消费启动期间排队的激活请求
   await activation.markReady();
 
-  return { runtime, services, channels, scheduler };
+  return { runtime, services, channels, plugins, scheduler };
 }

--- a/src/main/application/default-dependencies.ts
+++ b/src/main/application/default-dependencies.ts
@@ -90,6 +90,7 @@ import { registerCallIpc } from "../call/call-manager";
 import { initSkills, skillRegistry } from "../skills";
 import { createSchedulerSubsystem } from "../scheduler/bootstrap";
 import { createChannelsSubsystem } from "../channels/bootstrap";
+import { startPluginRuntime } from "../plugin-runtime";
 import { createAgentRuntime } from "../orchestrator/agent-runtime";
 import { createRuntimeStateService } from "../orchestrator/runtime-state-service";
 import { createProactiveLifecycle } from "../proactive/proactive-lifecycle";
@@ -376,6 +377,11 @@ export function createDefaultApplicationDependencies(): ApplicationDependencies 
         agentRuntime: runtime,
         ttsSynthesisService: services.tts,
         getReactChatWindow: () => reactChatWindow,
+        ipc: shell.ipc,
+      }),
+
+      startPlugins: (services) => startPluginRuntime({
+        llmClient: services.llm,
         ipc: shell.ipc,
       }),
 

--- a/src/main/application/ipc-scope.test.ts
+++ b/src/main/application/ipc-scope.test.ts
@@ -46,6 +46,16 @@ describe("createIpcScope", () => {
     expect(() => scope.handle("a", vi.fn())).toThrow("IPC channel already registered: a");
   });
 
+  it("supports dynamic handler removal without removing it again on dispose", () => {
+    const main = createFakeIpcMain();
+    const scope = createIpcScope(main);
+    scope.handle("plugin:demo:ping", vi.fn());
+    scope.removeHandler("plugin:demo:ping");
+    scope.dispose();
+    expect(main.removeHandler).toHaveBeenCalledTimes(1);
+    expect(main.handlers.has("plugin:demo:ping")).toBe(false);
+  });
+
   it("dispose is idempotent", () => {
     const main = createFakeIpcMain();
     const scope = createIpcScope(main);

--- a/src/main/application/ipc-scope.ts
+++ b/src/main/application/ipc-scope.ts
@@ -8,6 +8,7 @@ import { ipcMain } from "electron";
 
 export interface IpcScope {
   handle(channel: string, listener: (...args: any[]) => unknown): void;
+  removeHandler(channel: string): void;
   on(channel: string, listener: (...args: any[]) => void): void;
   dispose(): void;
 }
@@ -43,6 +44,16 @@ export function createIpcScope(main: IpcScopeMainLike = ipcMain as IpcScopeMainL
       handledChannels.add(channel);
       registrations.push({ kind: "handle", channel, listener });
       main.handle(channel, listener);
+    },
+
+    removeHandler(channel) {
+      assertActive();
+      if (!handledChannels.delete(channel)) return;
+      const index = registrations.findIndex(
+        (registration) => registration.kind === "handle" && registration.channel === channel,
+      );
+      if (index >= 0) registrations.splice(index, 1);
+      main.removeHandler(channel);
     },
 
     on(channel, listener) {

--- a/src/main/channels/bootstrap.test.ts
+++ b/src/main/channels/bootstrap.test.ts
@@ -72,6 +72,30 @@ describe("createChannelsSubsystem lifecycle", () => {
     expect(lifecycle.start).toHaveBeenCalledOnce();
   });
 
+  it("resolves adaptersRegistered only after synchronous adapter initialization succeeds", async () => {
+    const lifecycle = { initialize: vi.fn(), start: vi.fn(async () => undefined), shutdown: vi.fn() };
+    const subsystem = createChannelsSubsystem(makeChannelsDeps(), lifecycle);
+    let settled = false;
+    void subsystem.adaptersRegistered.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    subsystem.initialize();
+    await expect(subsystem.adaptersRegistered).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+  });
+
+  it("rejects adaptersRegistered when adapter initialization fails", async () => {
+    const lifecycle = {
+      initialize: vi.fn(() => { throw new Error("adapter registration failed"); }),
+      start: vi.fn(async () => undefined),
+      shutdown: vi.fn(),
+    };
+    const subsystem = createChannelsSubsystem(makeChannelsDeps(), lifecycle);
+    expect(() => subsystem.initialize()).toThrow("adapter registration failed");
+    await expect(subsystem.adaptersRegistered).rejects.toThrow("adapter registration failed");
+  });
+
   it("forwards the abort signal to the lifecycle start", async () => {
     const lifecycle = { initialize: vi.fn(), start: vi.fn(async () => undefined), shutdown: vi.fn() };
     const subsystem = createChannelsSubsystem(makeChannelsDeps(), lifecycle);

--- a/src/main/channels/bootstrap.ts
+++ b/src/main/channels/bootstrap.ts
@@ -39,6 +39,8 @@ export interface ChannelsLifecycleAdapter {
 export interface ChannelsSubsystem {
   initialize(): void;
   start(signal?: AbortSignal): Promise<void>;
+  /** initialize() 同步注册全部内置 adapter 后解析，插件必须等待该边界。 */
+  adaptersRegistered: Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -181,9 +183,25 @@ export function createChannelsSubsystem(
   };
   const adapter = lifecycle ?? defaultLifecycle;
 
+  let resolveAdaptersRegistered!: () => void;
+  let rejectAdaptersRegistered!: (error: unknown) => void;
+  const adaptersRegistered = new Promise<void>((resolve, reject) => {
+    resolveAdaptersRegistered = resolve;
+    rejectAdaptersRegistered = reject;
+  });
+
   return {
-    initialize: () => adapter.initialize(),
+    initialize: () => {
+      try {
+        adapter.initialize();
+        resolveAdaptersRegistered();
+      } catch (error) {
+        rejectAdaptersRegistered(error);
+        throw error;
+      }
+    },
     start: (signal?: AbortSignal) => adapter.start(signal),
+    adaptersRegistered,
     shutdown: () => adapter.shutdown(),
   };
 }

--- a/src/main/channels/init.ts
+++ b/src/main/channels/init.ts
@@ -61,7 +61,6 @@ function getPublicChannelsSettings(): Record<string, unknown> {
     },
   };
 }
-
 /** app 启动编排（core 阶段）调一次。只做装配，无网络副作用。idempotent。 */
 export function initializeChannels(ipcOption?: IpcScope): void {
   if (initialized) return;
@@ -100,7 +99,6 @@ function registerAdapters(): void {
   qqAdapter = new NapCatAdapter(broadcastChannelsStatus);
   channelManager.register(qqAdapter);
 
-  // 注册 QQ 官方机器人 adapter（QQ 开放平台 API v2，AppID/AppSecret + WebSocket 网关）
   qqBotAdapter = new QqBotAdapter(broadcastChannelsStatus);
   channelManager.register(qqBotAdapter);
 }

--- a/src/main/channels/manager.test.ts
+++ b/src/main/channels/manager.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { ChannelManager } from "./manager";
+import type { ChannelAdapter } from "./adapters/base";
+
+function fakeAdapter(id: string): ChannelAdapter {
+  let started = false;
+  return {
+    id: id as never,
+    displayName: id,
+    capability: {} as never,
+    onMessage: null,
+    start: async () => {
+      started = true;
+    },
+    stop: async () => {
+      started = false;
+    },
+    send: async () => ({ ok: true }),
+    getStatus: () => ({ enabled: started, phase: started ? "running" : "offline" }),
+  };
+}
+
+describe("ChannelManager", () => {
+  it("startOne 启动单个 adapter；unregister 先 stop 再移除", async () => {
+    const mgr = new ChannelManager();
+    const adapter = fakeAdapter("qq");
+    mgr.register(adapter);
+    await mgr.startOne("qq" as never);
+    expect(mgr.getAdapter("qq" as never)).toBeDefined();
+    expect(adapter.getStatus().phase).toBe("running");
+
+    const removed = await mgr.unregister("qq" as never);
+    expect(removed).toBe(true);
+    expect(mgr.getAdapter("qq" as never)).toBeUndefined();
+    expect(adapter.getStatus().phase).toBe("offline");
+  });
+
+  it("unregister 不存在的 id 返回 false", async () => {
+    const mgr = new ChannelManager();
+    expect(await mgr.unregister("nope" as never)).toBe(false);
+  });
+
+  it("startAll 跳过已启动的 adapter（避免渠道插件双启动）", async () => {
+    const mgr = new ChannelManager();
+    let startCount = 0;
+    const adapter = fakeAdapter("qq");
+    const origStart = adapter.start;
+    adapter.start = async () => {
+      startCount += 1;
+      await origStart();
+    };
+    mgr.register(adapter);
+    await mgr.startOne("qq" as never);
+    await mgr.startAll();
+    expect(startCount).toBe(1);
+  });
+});

--- a/src/main/channels/manager.test.ts
+++ b/src/main/channels/manager.test.ts
@@ -54,4 +54,27 @@ describe("ChannelManager", () => {
     await mgr.startAll();
     expect(startCount).toBe(1);
   });
+
+  it("拒绝重复 id，避免覆盖已启动 adapter 后留下错误状态", async () => {
+    const mgr = new ChannelManager();
+    const first = fakeAdapter("feishu");
+    const second = fakeAdapter("feishu");
+    mgr.register(first);
+    await mgr.startOne("feishu" as never);
+    expect(() => mgr.register(second)).toThrow(/禁止覆盖/);
+    expect(mgr.getAdapter("feishu" as never)).toBe(first);
+    expect(second.getStatus().phase).toBe("offline");
+  });
+
+  it("startOne 对已启动 adapter 幂等", async () => {
+    const mgr = new ChannelManager();
+    const adapter = fakeAdapter("qq");
+    let starts = 0;
+    const original = adapter.start;
+    adapter.start = async () => { starts += 1; await original(); };
+    mgr.register(adapter);
+    await mgr.startOne("qq" as never);
+    await mgr.startOne("qq" as never);
+    expect(starts).toBe(1);
+  });
 });

--- a/src/main/channels/manager.ts
+++ b/src/main/channels/manager.ts
@@ -26,10 +26,10 @@ export class ChannelManager {
     return this.adapters.has(id);
   }
 
-  /** 注册 adapter（必须在 startAll 之前调用） */
+  /** 注册 adapter（必须在 startAll 之前调用；重复 id 一律拒绝） */
   register(adapter: ChannelAdapter): void {
     if (this.adapters.has(adapter.id)) {
-      console.warn(LOG, `渠道 ${adapter.id} 已注册，覆盖旧实例`);
+      throw new Error(`渠道 ${adapter.id} 已注册，禁止覆盖现有实例`);
     }
     this.adapters.set(adapter.id, adapter);
   }
@@ -83,6 +83,7 @@ export class ChannelManager {
   async startOne(id: ChannelId): Promise<void> {
     const adapter = this.adapters.get(id);
     if (!adapter) return;
+    if (this.startedAdapters.has(id)) return;
     if (this.dispatchFn) {
       setAdapterHandler(adapter, this.makeAdapterHandler(id));
     }

--- a/src/main/channels/manager.ts
+++ b/src/main/channels/manager.ts
@@ -22,6 +22,10 @@ export class ChannelManager {
   /** 启动后已开启的 adapter（start 成功的才会调 stop） */
   private startedAdapters = new Set<ChannelId>();
 
+  has(id: ChannelId): boolean {
+    return this.adapters.has(id);
+  }
+
   /** 注册 adapter（必须在 startAll 之前调用） */
   register(adapter: ChannelAdapter): void {
     if (this.adapters.has(adapter.id)) {
@@ -42,6 +46,8 @@ export class ChannelManager {
   /** 启动所有已注册 adapter（失败的跳过、记 log） */
   async startAll(): Promise<void> {
     for (const adapter of this.adapters.values()) {
+      // 跳过已启动的 adapter（插件注册渠道场景：registerChannelAdapter 已 startOne）
+      if (this.startedAdapters.has(adapter.id)) continue;
       try {
         // 每次 start 前重新注入 handler（防止 setDispatcher 之前 adapter 已经被外部注入 null）
         if (this.dispatchFn) {
@@ -54,6 +60,35 @@ export class ChannelManager {
         console.error(LOG, `渠道启动失败 [${adapter.id}]:`, err instanceof Error ? err.message : err);
       }
     }
+  }
+
+  /** 注销 adapter：若已启动先 stop，再移除（运行时禁用插件渠道用） */
+  async unregister(id: ChannelId): Promise<boolean> {
+    const adapter = this.adapters.get(id);
+    if (!adapter) return false;
+    if (this.startedAdapters.has(id)) {
+      try {
+        await adapter.stop();
+      } catch (err) {
+        console.warn(LOG, `渠道停止失败 [${id}]:`, err instanceof Error ? err.message : err);
+      }
+      this.startedAdapters.delete(id);
+    }
+    this.adapters.delete(id);
+    logger.info(LogTag.Channels, `unregistered: ${id}`);
+    return true;
+  }
+
+  /** 启动单个 adapter（运行时启用插件渠道用） */
+  async startOne(id: ChannelId): Promise<void> {
+    const adapter = this.adapters.get(id);
+    if (!adapter) return;
+    if (this.dispatchFn) {
+      setAdapterHandler(adapter, this.makeAdapterHandler(id));
+    }
+    await adapter.start();
+    this.startedAdapters.add(id);
+    logger.info(LogTag.Channels, `started: ${id} (${adapter.displayName})`);
   }
 
   /** 关闭所有已启动的 adapter */

--- a/src/main/plugin-llm.test.ts
+++ b/src/main/plugin-llm.test.ts
@@ -1,45 +1,92 @@
-import { describe, expect, it } from "vitest";
-import { pluginGenerateText } from "./plugin-llm";
+import { describe, expect, it, vi } from "vitest";
+import type { LlmClient } from "./services/llm/llm-client";
+import type { ModelSettings } from "./settings/model-settings";
+import { pluginGenerateText, type EnqueuePluginLlmTask } from "./plugin-llm";
+
+function settings(patch: Partial<ModelSettings> = {}): ModelSettings {
+  return {
+    mode: "auto",
+    provider: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-5-mini",
+    apiKey: "secret",
+    explicitTransport: "openai",
+    perProvider: {},
+    runtimeSync: "off",
+    stickerEnabled: true,
+    stickerSize: "standard",
+    stickerSimilarityThreshold: 0.55,
+    chatRequestTimeoutSec: 300,
+    citaRepairBudgetSec: 8,
+    rerankerMode: "none",
+    embeddingModel: "bgem3",
+    multimodal: false,
+    contextWindowTokens: 128000,
+    ...patch,
+  };
+}
+
+function harness() {
+  const chatNonStream = vi.fn(async () => ({
+    text: "generated text",
+    finishReason: "stop",
+  }));
+  const llmClient = { chatNonStream } as unknown as LlmClient;
+  const labels: string[] = [];
+  const enqueueTask: EnqueuePluginLlmTask = async (label, task) => {
+    labels.push(label);
+    return task();
+  };
+  return { chatNonStream, llmClient, enqueueTask, labels };
+}
 
 describe("pluginGenerateText", () => {
-  it("复用当前主模型配置发送非流式文本请求", async () => {
-    let capturedBody: unknown;
-    let calls = 0;
-    const fetchImpl = (async (_input: unknown, init?: { body?: unknown }) => {
-      calls += 1;
-      capturedBody = init?.body;
-      return new Response(
-        JSON.stringify({ choices: [{ message: { content: "generated text" } }] }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }) as unknown as typeof fetch;
-
+  it("通过统一 LlmClient 和后台队列发送非流式请求", async () => {
+    const h = harness();
     const result = await pluginGenerateText(
       [{ role: "user", content: "Write a short greeting" }],
-      {
-        provider: "OpenAI",
-        baseUrl: "https://api.openai.com/v1",
-        model: "gpt-5-mini",
-        apiKey: "secret",
-        explicitTransport: "openai",
-      },
-      fetchImpl,
+      settings(),
+      h.llmClient,
+      h.enqueueTask,
+      { maxTokens: 2048, timeoutMs: 5000, purpose: "demo:summary" },
     );
 
     expect(result).toBe("generated text");
-    expect(calls).toBe(1);
-    expect(JSON.parse(String(capturedBody))).toMatchObject({
-      model: "gpt-5-mini",
-      stream: false,
-    });
+    expect(h.labels).toEqual(["plugin:demo:summary"]);
+    expect(h.chatNonStream).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-5-mini" }),
+      [{ role: "user", content: "Write a short greeting" }],
+      undefined,
+      5000,
+      "plugin:demo:summary",
+      undefined,
+      { maxTokens: 2048 },
+      undefined,
+    );
   });
 
   it("没有 API Key 时拒绝请求", async () => {
+    const h = harness();
     await expect(
       pluginGenerateText(
         [{ role: "user", content: "你好" }],
-        { provider: "OpenAI", baseUrl: "https://api.openai.com/v1", model: "gpt-5-mini", apiKey: "" },
+        settings({ apiKey: "" }),
+        h.llmClient,
+        h.enqueueTask,
       ),
     ).rejects.toThrow(/API Key/);
+  });
+
+  it("限制 maxTokens 和 timeoutMs，避免插件制造无界请求", async () => {
+    const h = harness();
+    await expect(
+      pluginGenerateText(
+        [{ role: "user", content: "你好" }],
+        settings(),
+        h.llmClient,
+        h.enqueueTask,
+        { maxTokens: 9000 },
+      ),
+    ).rejects.toThrow(/maxTokens/);
   });
 });

--- a/src/main/plugin-llm.test.ts
+++ b/src/main/plugin-llm.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { pluginGenerateText } from "./plugin-llm";
+
+describe("pluginGenerateText", () => {
+  it("复用当前主模型配置发送非流式文本请求", async () => {
+    let capturedBody: unknown;
+    let calls = 0;
+    const fetchImpl = (async (_input: unknown, init?: { body?: unknown }) => {
+      calls += 1;
+      capturedBody = init?.body;
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "generated text" } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await pluginGenerateText(
+      [{ role: "user", content: "Write a short greeting" }],
+      {
+        provider: "OpenAI",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-5-mini",
+        apiKey: "secret",
+        explicitTransport: "openai",
+      },
+      fetchImpl,
+    );
+
+    expect(result).toBe("generated text");
+    expect(calls).toBe(1);
+    expect(JSON.parse(String(capturedBody))).toMatchObject({
+      model: "gpt-5-mini",
+      stream: false,
+    });
+  });
+
+  it("没有 API Key 时拒绝请求", async () => {
+    await expect(
+      pluginGenerateText(
+        [{ role: "user", content: "你好" }],
+        { provider: "OpenAI", baseUrl: "https://api.openai.com/v1", model: "gpt-5-mini", apiKey: "" },
+      ),
+    ).rejects.toThrow(/API Key/);
+  });
+});

--- a/src/main/plugin-llm.ts
+++ b/src/main/plugin-llm.ts
@@ -1,0 +1,53 @@
+import { getAdapterForConfig } from "./orchestrator/vendors";
+import type { ChatMessage, Transport, VendorConfig } from "./orchestrator/vendors/types";
+
+export interface PluginLlmSettings {
+  provider: string;
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+  explicitTransport?: Transport | "auto";
+}
+
+export async function pluginGenerateText(
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+  settings: PluginLlmSettings,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  if (!settings.apiKey.trim()) {
+    throw new Error("未配置 API Key，请先在设置页配置主聊天模型");
+  }
+  if (!settings.model.trim()) {
+    throw new Error("未配置主聊天模型名称");
+  }
+
+  const config: VendorConfig = {
+    provider: settings.provider,
+    baseUrl: settings.baseUrl,
+    model: settings.model,
+    apiKey: settings.apiKey,
+    explicitTransport: settings.explicitTransport,
+  };
+  const adapter = getAdapterForConfig(config);
+  const request = adapter.buildRequest(
+    {
+      model: config.model,
+      messages: messages as ChatMessage[],
+      maxTokens: 1024,
+      stream: false,
+    },
+    config,
+  );
+  const response = await fetchImpl(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body: request.body,
+  });
+  if (!response.ok) {
+    throw new Error(`插件模型请求失败: HTTP ${response.status}`);
+  }
+  const parsed = adapter.parseResponse(await response.json());
+  const text = parsed.text?.trim();
+  if (!text) throw new Error("主聊天模型没有返回文本");
+  return text;
+}

--- a/src/main/plugin-llm.ts
+++ b/src/main/plugin-llm.ts
@@ -1,18 +1,38 @@
-import { getAdapterForConfig } from "./orchestrator/vendors";
-import type { ChatMessage, Transport, VendorConfig } from "./orchestrator/vendors/types";
+import type { PluginLlmGenerateOptions, PluginLlmMessage } from "../plugins/api";
+import type { LlmClient } from "./services/llm/llm-client";
+import type { ModelSettings } from "./settings/model-settings";
 
-export interface PluginLlmSettings {
-  provider: string;
-  baseUrl: string;
-  model: string;
-  apiKey: string;
-  explicitTransport?: Transport | "auto";
+export type EnqueuePluginLlmTask = <T>(
+  label: string,
+  task: () => Promise<T>,
+  options?: { log?: boolean; retryRateLimit?: boolean },
+) => Promise<T>;
+
+function clampInteger(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+  field: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${field} 必须是 ${min}-${max} 的整数`);
+  }
+  return value;
+}
+
+function safePurpose(value: string | undefined): string {
+  const normalized = value?.trim().replace(/[^a-zA-Z0-9._:-]+/g, "-");
+  return normalized?.slice(0, 80) || "unknown";
 }
 
 export async function pluginGenerateText(
-  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
-  settings: PluginLlmSettings,
-  fetchImpl: typeof fetch = fetch,
+  messages: PluginLlmMessage[],
+  settings: ModelSettings,
+  llmClient: LlmClient,
+  enqueueTask: EnqueuePluginLlmTask,
+  options: PluginLlmGenerateOptions = {},
 ): Promise<string> {
   if (!settings.apiKey.trim()) {
     throw new Error("未配置 API Key，请先在设置页配置主聊天模型");
@@ -20,34 +40,35 @@ export async function pluginGenerateText(
   if (!settings.model.trim()) {
     throw new Error("未配置主聊天模型名称");
   }
-
-  const config: VendorConfig = {
-    provider: settings.provider,
-    baseUrl: settings.baseUrl,
-    model: settings.model,
-    apiKey: settings.apiKey,
-    explicitTransport: settings.explicitTransport,
-  };
-  const adapter = getAdapterForConfig(config);
-  const request = adapter.buildRequest(
-    {
-      model: config.model,
-      messages: messages as ChatMessage[],
-      maxTokens: 1024,
-      stream: false,
-    },
-    config,
-  );
-  const response = await fetchImpl(request.url, {
-    method: "POST",
-    headers: request.headers,
-    body: request.body,
-  });
-  if (!response.ok) {
-    throw new Error(`插件模型请求失败: HTTP ${response.status}`);
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error("插件模型请求至少需要一条消息");
   }
-  const parsed = adapter.parseResponse(await response.json());
-  const text = parsed.text?.trim();
-  if (!text) throw new Error("主聊天模型没有返回文本");
-  return text;
+
+  const maxTokens = clampInteger(options.maxTokens, 1024, 1, 8192, "maxTokens");
+  const defaultTimeout = Math.min(
+    Math.max(settings.chatRequestTimeoutSec * 1000, 1000),
+    120_000,
+  );
+  const timeoutMs = clampInteger(options.timeoutMs, defaultTimeout, 1000, 300_000, "timeoutMs");
+  const label = `plugin:${safePurpose(options.purpose)}`;
+
+  return enqueueTask(
+    label,
+    async () => {
+      const result = await llmClient.chatNonStream(
+        settings,
+        messages,
+        undefined,
+        timeoutMs,
+        label,
+        undefined,
+        { maxTokens },
+        options.signal,
+      );
+      const text = result.text?.trim();
+      if (!text) throw new Error("主聊天模型没有返回文本");
+      return text;
+    },
+    { retryRateLimit: true },
+  );
 }

--- a/src/main/plugin-runtime.ts
+++ b/src/main/plugin-runtime.ts
@@ -1,18 +1,29 @@
-import { app, ipcMain } from "electron";
+import { app } from "electron";
 import path from "node:path";
 import { channelManager } from "./channels/manager";
 import type { ChannelId } from "./channels/types";
-import { toolRegistry } from "./orchestrator/tool-registry";
+import { toolRegistry } from "./orchestrator/tools/registry/tool-registry";
 import { loadGeneralSettings, saveGeneralSettings } from "./settings/settings-facade";
-import { loadModelSettings } from "./settings/model-settings";
+import { loadModelSettings, resolveModelSettingsProfile } from "./settings/model-settings";
 import { pluginGenerateText } from "./plugin-llm";
 import { PluginManager } from "../plugins/manager";
+import type { LlmClient } from "./services/llm/llm-client";
+import { enqueueLLMTask } from "./llm-queue";
+import type { IpcScope } from "./application/ipc-scope";
 
-export async function startPluginRuntime(): Promise<PluginManager> {
+export interface PluginRuntimeDeps {
+  llmClient: LlmClient;
+  ipc: IpcScope;
+}
+
+export async function startPluginRuntime(deps: PluginRuntimeDeps): Promise<PluginManager> {
   const userPluginRoot = path.join(app.getPath("userData"), "plugins");
   const pluginDataRoot = path.join(app.getPath("userData"), "plugin-data");
   const manager = new PluginManager({
-    scanRoots: [path.join(__dirname, "..", "plugins"), userPluginRoot],
+    scanRoots: [
+      { path: path.join(__dirname, "..", "plugins"), source: "builtin" },
+      { path: userPluginRoot, source: "user" },
+    ],
     storageRoot: pluginDataRoot,
     runtime: {
       toolRegistry,
@@ -23,11 +34,17 @@ export async function startPluginRuntime(): Promise<PluginManager> {
         startOne: (id) => channelManager.startOne(id as ChannelId),
       },
       registerIpc: (channel, handler) => {
-        ipcMain.handle(channel, (_event, ...args: unknown[]) => handler(...args));
+        deps.ipc.handle(channel, (_event, ...args: unknown[]) => handler(...args));
       },
-      unregisterIpc: (channel) => ipcMain.removeHandler(channel),
+      unregisterIpc: (channel) => deps.ipc.removeHandler(channel),
       llm: {
-        generateText: (messages) => pluginGenerateText(messages, loadModelSettings()),
+        generateText: (messages, options) => pluginGenerateText(
+          messages,
+          resolveModelSettingsProfile(loadModelSettings()),
+          deps.llmClient,
+          enqueueLLMTask,
+          options,
+        ),
       },
     },
     loadEnabledMap: () => loadGeneralSettings().plugins,

--- a/src/main/plugin-runtime.ts
+++ b/src/main/plugin-runtime.ts
@@ -1,0 +1,38 @@
+import { app, ipcMain } from "electron";
+import path from "node:path";
+import { channelManager } from "./channels/manager";
+import type { ChannelId } from "./channels/types";
+import { toolRegistry } from "./orchestrator/tool-registry";
+import { loadGeneralSettings, saveGeneralSettings } from "./settings/settings-facade";
+import { loadModelSettings } from "./settings/model-settings";
+import { pluginGenerateText } from "./plugin-llm";
+import { PluginManager } from "../plugins/manager";
+
+export async function startPluginRuntime(): Promise<PluginManager> {
+  const userPluginRoot = path.join(app.getPath("userData"), "plugins");
+  const pluginDataRoot = path.join(app.getPath("userData"), "plugin-data");
+  const manager = new PluginManager({
+    scanRoots: [path.join(__dirname, "..", "plugins"), userPluginRoot],
+    storageRoot: pluginDataRoot,
+    runtime: {
+      toolRegistry,
+      channelManager: {
+        has: (id) => channelManager.has(id as ChannelId),
+        register: (adapter) => channelManager.register(adapter),
+        unregister: (id) => channelManager.unregister(id as ChannelId),
+        startOne: (id) => channelManager.startOne(id as ChannelId),
+      },
+      registerIpc: (channel, handler) => {
+        ipcMain.handle(channel, (_event, ...args: unknown[]) => handler(...args));
+      },
+      unregisterIpc: (channel) => ipcMain.removeHandler(channel),
+      llm: {
+        generateText: (messages) => pluginGenerateText(messages, loadModelSettings()),
+      },
+    },
+    loadEnabledMap: () => loadGeneralSettings().plugins,
+    saveEnabledMap: (plugins) => saveGeneralSettings({ plugins }),
+  });
+  await manager.start();
+  return manager;
+}

--- a/src/main/settings/general-settings.ts
+++ b/src/main/settings/general-settings.ts
@@ -19,6 +19,8 @@ import type { LspServerOverride } from "../lsp/types";
  * 与 ChatAppearanceSettings 组合，统一保存到 general-settings.json。
  */
 export interface GeneralSettings extends ChatAppearanceSettings {
+  /** 功能插件开关表：pluginId -> enabled */
+  plugins: Record<string, boolean>;
   /** Harness 同时执行已明确安全工具的上限；1 表示完全串行。 */
   maxParallelToolCalls: number;
   citaEnabled: boolean;

--- a/src/main/settings/settings-facade.ts
+++ b/src/main/settings/settings-facade.ts
@@ -36,6 +36,7 @@ import {
 } from "./launch-at-login";
 
 const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
+  plugins: {},
   maxParallelToolCalls: 4,
   citaEnabled: false,
   citaSemanticEngine: "remote",
@@ -169,6 +170,11 @@ export function normalizeGeneralSettings(
       : DEFAULT_GENERAL_SETTINGS.maxParallelToolCalls;
   };
   return {
+    plugins: Object.fromEntries(
+      Object.entries(input?.plugins ?? {}).filter(
+        (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+      ),
+    ),
     maxParallelToolCalls: normalizeMaxParallelToolCalls(input?.maxParallelToolCalls),
     citaEnabled: cita.enabled,
     citaSemanticEngine: cita.semanticEngine,

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -1,0 +1,189 @@
+/**
+ * Cyrene Plugin API v1.
+ *
+ * This file is the stable, plugin-facing contract. It deliberately does not
+ * import from src/main or src/shared so internal application refactors do not
+ * leak into third-party plugin types.
+ */
+
+export const CURRENT_PLUGIN_API_VERSION = 1 as const;
+
+export type PluginCapability = "channels" | "llm";
+
+export interface PluginManifest {
+  /** Plugin API major version required by this plugin. */
+  apiVersion: number;
+  /** Unique lowercase id, for example "my-plugin". */
+  id: string;
+  name: string;
+  /** Strict SemVer plugin version. */
+  version: string;
+  description: string;
+  author: string;
+  /** Bare file name inside the plugin directory. */
+  entry: string;
+  /** Honored only for bundled plugins. User plugins always require opt-in. */
+  defaultEnabled: boolean;
+  /** Host services requested from Cyrene. This is not a security sandbox. */
+  deps?: PluginCapability[];
+}
+
+export type PluginJsonSchema = {
+  type: string;
+  description?: string;
+  enum?: string[];
+  default?: unknown;
+  properties?: Record<string, PluginJsonSchema>;
+  items?: PluginJsonSchema;
+  required?: string[];
+};
+
+export interface PluginToolContext {
+  userQuery: string;
+  conversationId?: string;
+  runId?: string;
+  signal?: AbortSignal;
+  resolvedWorkspaceRoot?: string;
+  mode?: "chat" | "learn" | "code" | "work";
+  permissionMode?: "normal" | "allow_all";
+  metadata?: Record<string, unknown>;
+}
+
+export interface PluginTool {
+  id: string;
+  name: string;
+  description: string;
+  catalogHint?: string;
+  category?: string;
+  capability?: string;
+  enabled: boolean;
+  risk?: "safe" | "fs-read" | "fs-write" | "shell" | "network" | "input-control";
+  modes?: Array<"learn" | "code" | "work">;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, PluginJsonSchema>;
+    required?: string[];
+  };
+  needsContext?: boolean;
+  ledgerPolicy?: "success_terminal" | "bypass";
+  deprecated?: boolean;
+  effectKind?: "read" | "mutation" | "verification" | "external_side_effect" | "unknown";
+  verificationPolicy?: "none" | "artifact" | "code" | "unknown";
+  execute(args: Record<string, unknown>, ctx?: PluginToolContext): Promise<string>;
+}
+
+export interface PluginChannelCapability {
+  text: boolean;
+  image: boolean;
+  audio: boolean;
+  file: boolean;
+  video: boolean;
+  markdown: boolean;
+  card: boolean;
+  sticker: boolean;
+  maxTextLength: number;
+}
+
+export interface PluginChannelStatus {
+  enabled: boolean;
+  phase: "running" | "offline" | "starting" | "config_missing" | "error";
+  message?: string;
+}
+
+export interface PluginIncomingMessage {
+  channel: string;
+  chatType?: "private" | "group";
+  messageId?: string;
+  senderId: string;
+  senderName?: string;
+  chatId: string;
+  threadId?: string;
+  text: string;
+  attachments?: Array<{
+    kind: "image" | "audio" | "file" | "video";
+    url?: string;
+    filePath?: string;
+    mime?: string;
+    caption?: string;
+  }>;
+  at: Date;
+  _raw?: unknown;
+}
+
+export interface PluginOutgoingMessage {
+  channel: string;
+  chatType?: "private" | "group";
+  targetId: string;
+  threadId?: string;
+  parts: Array<Record<string, unknown> & { kind: string }>;
+}
+
+export type PluginMessageHandler = (
+  message: PluginIncomingMessage,
+) => Promise<PluginOutgoingMessage | null>;
+
+export interface PluginChannelAdapter {
+  readonly id: string;
+  readonly displayName: string;
+  readonly capability: PluginChannelCapability;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  onMessage: PluginMessageHandler | null;
+  send(message: PluginOutgoingMessage): Promise<{ ok: boolean; error?: string }>;
+  getStatus(): PluginChannelStatus;
+}
+
+export interface PluginLlmMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface PluginLlmGenerateOptions {
+  /** 1-8192; defaults to 1024. */
+  maxTokens?: number;
+  /** 1000-300000 ms; defaults to the current chat timeout capped at 120s. */
+  timeoutMs?: number;
+  /** Optional cancellation signal owned by the plugin. */
+  signal?: AbortSignal;
+  /** Short diagnostic label appended to plugin:<id>. */
+  purpose?: string;
+}
+
+export interface PluginLlmService {
+  generateText(
+    messages: PluginLlmMessage[],
+    options?: PluginLlmGenerateOptions,
+  ): Promise<string>;
+}
+
+export interface PluginStorage {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  rootDir(): string;
+}
+
+export interface PluginDeps {
+  /** Read-only channel discovery. Registration must use PluginContext methods. */
+  channels?: { has(id: string): boolean };
+  llm?: PluginLlmService;
+}
+
+export interface PluginContext {
+  id: string;
+  registerTool(tool: PluginTool): void;
+  unregisterTool(toolId: string): void;
+  /** Automatically namespaced as plugin:<id>:<channel>. */
+  registerIpc(channel: string, handler: (...args: unknown[]) => unknown): void;
+  unregisterIpc(channel: string): void;
+  registerChannelAdapter(adapter: PluginChannelAdapter): Promise<void>;
+  unregisterChannelAdapter(channelId: string): Promise<void>;
+  storage: PluginStorage;
+  deps: PluginDeps;
+  log(...args: unknown[]): void;
+}
+
+export interface CyrenePlugin {
+  open?(): void | Promise<void>;
+  register(ctx: PluginContext): void | Promise<void>;
+  unregister?(): void | Promise<void>;
+}

--- a/src/plugins/context.test.ts
+++ b/src/plugins/context.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChannelAdapter } from "../main/channels/adapters/base";
+import { createContext, type PluginRuntime } from "./context";
+
+let tmp: string;
+
+afterEach(() => {
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = "";
+  }
+});
+
+function runtime(): PluginRuntime & { tools: string[]; ipc: Map<string, unknown> } {
+  const tools: string[] = [];
+  const ipc = new Map<string, unknown>();
+  return {
+    tools,
+    ipc,
+    toolRegistry: {
+      register: (t) => tools.push(t.id),
+      unregister: (id) => {
+        const i = tools.indexOf(id);
+        if (i >= 0) tools.splice(i, 1);
+        return true;
+      },
+    },
+    channelManager: { has: () => false, register: () => {}, unregister: async () => true, startOne: async () => {} },
+    registerIpc: (c, h) => ipc.set(c, h),
+    unregisterIpc: (c) => ipc.delete(c),
+  };
+}
+
+describe("createContext", () => {
+  it("registerIpc 自动加 plugin:<id>: 前缀", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    const ctx = createContext("demo", tmp, rt);
+    ctx.registerIpc("ping", () => "pong");
+    expect(rt.ipc.has("plugin:demo:ping")).toBe(true);
+  });
+
+  it("dispose 清理已注册工具与 IPC", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    const ctx = createContext("demo", tmp, rt);
+    ctx.registerTool({
+      id: "demo_tool",
+      name: "t",
+      description: "d",
+      enabled: true,
+      inputSchema: { type: "object", properties: {}, required: [] },
+      execute: async () => "ok",
+    });
+    ctx.registerIpc("ping", () => "pong");
+    await ctx.dispose();
+    expect(rt.tools).toEqual([]);
+    expect(rt.ipc.has("plugin:demo:ping")).toBe(false);
+  });
+
+  it("storage 可读写", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const ctx = createContext("demo", tmp, runtime());
+    ctx.storage.set("k", 1);
+    expect(ctx.storage.get<number>("k")).toBe(1);
+  });
+
+  it("工具 id 不满足 <插件id>_ 前缀时抛错", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const ctx = createContext("demo", tmp, runtime());
+    expect(() =>
+      ctx.registerTool({
+        id: "bad_tool",
+        name: "t",
+        description: "d",
+        enabled: true,
+        inputSchema: { type: "object", properties: {}, required: [] },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/demo_/);
+  });
+
+  it("拒绝覆盖已注册工具", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    rt.toolRegistry.getById = () => ({ id: "demo_tool" } as never);
+    const ctx = createContext("demo", tmp, rt);
+    expect(() =>
+      ctx.registerTool({
+        id: "demo_tool",
+        name: "t",
+        description: "d",
+        enabled: true,
+        inputSchema: { type: "object", properties: {}, required: [] },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/已被占用/);
+    expect(rt.tools).toEqual([]);
+  });
+
+  it("拒绝覆盖已注册渠道", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    rt.channelManager.has = () => true;
+    const ctx = createContext("demo", tmp, rt, ["channels"]);
+    const adapter = { id: "wechat" } as ChannelAdapter;
+    await expect(ctx.registerChannelAdapter(adapter)).rejects.toThrow(/已被占用/);
+  });
+
+  it("未声明 deps 时不注入 channels；声明后注入", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const without = createContext("demo", tmp, runtime());
+    expect(without.deps.channels).toBeUndefined();
+    const withDeps = createContext("demo", tmp, runtime(), ["channels"]);
+    expect(withDeps.deps.channels?.channelManager).toBeDefined();
+  });
+
+  it("只有 manifest 声明 llm 时才注入 generateText", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    const calls: string[] = [];
+    rt.llm = {
+      generateText: async (messages) => {
+        calls.push(messages.map((message) => message.content).join("|"));
+        return "模型结果";
+      },
+    };
+
+    const without = createContext("demo", tmp, rt);
+    expect(without.deps.llm).toBeUndefined();
+
+    const withDeps = createContext("demo", tmp, rt, ["llm"]);
+    const result = await withDeps.deps.llm?.generateText([
+      { role: "user", content: "你好" },
+    ]);
+    expect(result).toBe("模型结果");
+    expect(calls).toEqual(["你好"]);
+  });
+
+  it("dispose 返回 Promise 并等待渠道注销完成", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const rt = runtime();
+    let releaseUnregister!: () => void;
+    let unregisterFinished = false;
+    rt.channelManager.unregister = async () => {
+      await new Promise<void>((resolve) => {
+        releaseUnregister = resolve;
+      });
+      unregisterFinished = true;
+      return true;
+    };
+    const adapter: ChannelAdapter = {
+      id: "wechat",
+      displayName: "test",
+      capability: {
+        text: true,
+        image: false,
+        audio: false,
+        file: false,
+        video: false,
+        markdown: false,
+        card: false,
+        sticker: false,
+        maxTextLength: 100,
+      },
+      start: async () => {},
+      stop: async () => {},
+      onMessage: null,
+      send: async () => ({ ok: true }),
+      getStatus: () => ({ enabled: true, phase: "running" }),
+    };
+    const ctx = createContext("demo", tmp, rt, ["channels"]);
+    await ctx.registerChannelAdapter(adapter);
+
+    const disposing = ctx.dispose();
+    expect(disposing).toBeInstanceOf(Promise);
+    expect(unregisterFinished).toBe(false);
+    releaseUnregister();
+    await disposing;
+    expect(unregisterFinished).toBe(true);
+  });
+});

--- a/src/plugins/context.test.ts
+++ b/src/plugins/context.test.ts
@@ -115,7 +115,7 @@ describe("createContext", () => {
     const without = createContext("demo", tmp, runtime());
     expect(without.deps.channels).toBeUndefined();
     const withDeps = createContext("demo", tmp, runtime(), ["channels"]);
-    expect(withDeps.deps.channels?.channelManager).toBeDefined();
+    expect(withDeps.deps.channels?.has("wechat")).toBe(false);
   });
 
   it("只有 manifest 声明 llm 时才注入 generateText", async () => {
@@ -181,5 +181,13 @@ describe("createContext", () => {
     releaseUnregister();
     await disposing;
     expect(unregisterFinished).toBe(true);
+  });
+
+  it("拒绝注销不属于当前插件的工具、IPC 和渠道", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-ctx-test-"));
+    const ctx = createContext("demo", tmp, runtime(), ["channels"]);
+    expect(() => ctx.unregisterTool("read_file")).toThrow(/不属于当前插件/);
+    expect(() => ctx.unregisterIpc("missing")).toThrow(/不属于当前插件/);
+    await expect(ctx.unregisterChannelAdapter("wechat")).rejects.toThrow(/不属于当前插件/);
   });
 });

--- a/src/plugins/context.ts
+++ b/src/plugins/context.ts
@@ -1,13 +1,16 @@
 import type { ChannelAdapter } from "../main/channels/adapters/base";
-import type { ToolDefinition } from "../main/orchestrator/tool-registry";
+import type { ToolDefinition } from "../main/orchestrator/tools/registry/tool-registry";
 import { createPluginStorage } from "./storage";
 import type {
-  ChannelManagerLike,
-  LlmDeps,
+  PluginChannelAdapter,
   PluginContext,
   PluginDeps,
+  PluginLlmService,
   PluginManifest,
+  PluginTool,
 } from "./types";
+
+const IPC_SEGMENT_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
 export interface PluginRuntime {
   toolRegistry: {
@@ -16,10 +19,15 @@ export interface PluginRuntime {
     /** 供冲突告警使用；不存在时跳过 */
     getById?(id: string): ToolDefinition | undefined;
   };
-  channelManager: ChannelManagerLike;
+  channelManager: {
+    has(id: string): boolean;
+    register(adapter: ChannelAdapter): void;
+    unregister(id: string): Promise<boolean>;
+    startOne(id: string): Promise<void>;
+  };
   registerIpc: (channel: string, handler: (...args: unknown[]) => unknown) => void;
   unregisterIpc: (channel: string) => void;
-  llm?: LlmDeps;
+  llm?: PluginLlmService;
 }
 
 interface DisposableContext extends PluginContext {
@@ -40,45 +48,68 @@ export function createContext(
   // deps 白名单生效：只有 manifest.deps 声明的依赖才会注入
   const deps: PluginDeps = {};
   if (declaredDeps?.includes("channels")) {
-    deps.channels = { channelManager: runtime.channelManager };
+    deps.channels = { has: (channelId) => runtime.channelManager.has(channelId) };
   }
   if (declaredDeps?.includes("llm") && runtime.llm) {
-    deps.llm = runtime.llm;
+    deps.llm = {
+      generateText: (messages, options) => runtime.llm!.generateText(messages, {
+        ...options,
+        purpose: options?.purpose ? `${id}:${options.purpose}` : id,
+      }),
+    };
   }
 
   const ctx: PluginContext = {
     id,
-    registerTool(tool: ToolDefinition) {
+    registerTool(tool: PluginTool) {
       const expectedPrefix = `${id}_`;
       if (!tool.id.startsWith(expectedPrefix)) {
         throw new Error(`插件工具 id 必须以 "${expectedPrefix}" 开头: ${tool.id}`);
+      }
+      if (registeredTools.has(tool.id)) {
+        throw new Error(`插件工具 id 已由当前插件注册: ${tool.id}`);
       }
       const existing = runtime.toolRegistry.getById?.(tool.id);
       if (existing) {
         throw new Error(`插件工具 id 已被占用: ${tool.id}`);
       }
-      runtime.toolRegistry.register(tool);
+      runtime.toolRegistry.register(tool as ToolDefinition);
       registeredTools.add(tool.id);
     },
     unregisterTool(toolId: string) {
+      if (!registeredTools.has(toolId)) {
+        throw new Error(`不能注销不属于当前插件的工具: ${toolId}`);
+      }
       runtime.toolRegistry.unregister(toolId);
       registeredTools.delete(toolId);
     },
     registerIpc(channel: string, handler: (...args: unknown[]) => unknown) {
+      if (!IPC_SEGMENT_RE.test(channel)) {
+        throw new Error(`非法插件 IPC channel: ${channel}`);
+      }
       const full = `plugin:${id}:${channel}`;
+      if (registeredIpc.has(full)) {
+        throw new Error(`插件 IPC channel 已注册: ${channel}`);
+      }
       runtime.registerIpc(full, handler);
       registeredIpc.add(full);
     },
     unregisterIpc(channel: string) {
       const full = `plugin:${id}:${channel}`;
+      if (!registeredIpc.has(full)) {
+        throw new Error(`不能注销不属于当前插件的 IPC channel: ${channel}`);
+      }
       runtime.unregisterIpc(full);
       registeredIpc.delete(full);
     },
-    async registerChannelAdapter(adapter: ChannelAdapter) {
+    async registerChannelAdapter(adapter: PluginChannelAdapter) {
+      if (registeredAdapters.has(adapter.id)) {
+        throw new Error(`插件渠道 id 已由当前插件注册: ${adapter.id}`);
+      }
       if (runtime.channelManager.has(adapter.id)) {
         throw new Error(`插件渠道 id 已被占用: ${adapter.id}`);
       }
-      runtime.channelManager.register(adapter);
+      runtime.channelManager.register(adapter as unknown as ChannelAdapter);
       try {
         await runtime.channelManager.startOne(adapter.id);
       } catch (err) {
@@ -89,6 +120,9 @@ export function createContext(
       registeredAdapters.add(adapter.id);
     },
     async unregisterChannelAdapter(channelId: string) {
+      if (!registeredAdapters.has(channelId)) {
+        throw new Error(`不能注销不属于当前插件的渠道: ${channelId}`);
+      }
       await runtime.channelManager.unregister(channelId);
       registeredAdapters.delete(channelId);
     },

--- a/src/plugins/context.ts
+++ b/src/plugins/context.ts
@@ -1,0 +1,134 @@
+import type { ChannelAdapter } from "../main/channels/adapters/base";
+import type { ToolDefinition } from "../main/orchestrator/tool-registry";
+import { createPluginStorage } from "./storage";
+import type {
+  ChannelManagerLike,
+  LlmDeps,
+  PluginContext,
+  PluginDeps,
+  PluginManifest,
+} from "./types";
+
+export interface PluginRuntime {
+  toolRegistry: {
+    register(tool: ToolDefinition): void;
+    unregister(id: string): boolean;
+    /** 供冲突告警使用；不存在时跳过 */
+    getById?(id: string): ToolDefinition | undefined;
+  };
+  channelManager: ChannelManagerLike;
+  registerIpc: (channel: string, handler: (...args: unknown[]) => unknown) => void;
+  unregisterIpc: (channel: string) => void;
+  llm?: LlmDeps;
+}
+
+interface DisposableContext extends PluginContext {
+  /** 框架内部：卸载插件时统一清理已注册资源 */
+  dispose(): Promise<void>;
+}
+
+export function createContext(
+  id: string,
+  storageRoot: string,
+  runtime: PluginRuntime,
+  declaredDeps?: PluginManifest["deps"],
+): DisposableContext {
+  const registeredTools = new Set<string>();
+  const registeredIpc = new Set<string>();
+  const registeredAdapters = new Set<string>();
+
+  // deps 白名单生效：只有 manifest.deps 声明的依赖才会注入
+  const deps: PluginDeps = {};
+  if (declaredDeps?.includes("channels")) {
+    deps.channels = { channelManager: runtime.channelManager };
+  }
+  if (declaredDeps?.includes("llm") && runtime.llm) {
+    deps.llm = runtime.llm;
+  }
+
+  const ctx: PluginContext = {
+    id,
+    registerTool(tool: ToolDefinition) {
+      const expectedPrefix = `${id}_`;
+      if (!tool.id.startsWith(expectedPrefix)) {
+        throw new Error(`插件工具 id 必须以 "${expectedPrefix}" 开头: ${tool.id}`);
+      }
+      const existing = runtime.toolRegistry.getById?.(tool.id);
+      if (existing) {
+        throw new Error(`插件工具 id 已被占用: ${tool.id}`);
+      }
+      runtime.toolRegistry.register(tool);
+      registeredTools.add(tool.id);
+    },
+    unregisterTool(toolId: string) {
+      runtime.toolRegistry.unregister(toolId);
+      registeredTools.delete(toolId);
+    },
+    registerIpc(channel: string, handler: (...args: unknown[]) => unknown) {
+      const full = `plugin:${id}:${channel}`;
+      runtime.registerIpc(full, handler);
+      registeredIpc.add(full);
+    },
+    unregisterIpc(channel: string) {
+      const full = `plugin:${id}:${channel}`;
+      runtime.unregisterIpc(full);
+      registeredIpc.delete(full);
+    },
+    async registerChannelAdapter(adapter: ChannelAdapter) {
+      if (runtime.channelManager.has(adapter.id)) {
+        throw new Error(`插件渠道 id 已被占用: ${adapter.id}`);
+      }
+      runtime.channelManager.register(adapter);
+      try {
+        await runtime.channelManager.startOne(adapter.id);
+      } catch (err) {
+        // 半成功回滚：start 失败时撤销已注册的 adapter，避免 dispose 遗漏
+        await runtime.channelManager.unregister(adapter.id);
+        throw err;
+      }
+      registeredAdapters.add(adapter.id);
+    },
+    async unregisterChannelAdapter(channelId: string) {
+      await runtime.channelManager.unregister(channelId);
+      registeredAdapters.delete(channelId);
+    },
+    storage: createPluginStorage(storageRoot),
+    deps,
+    log(...args: unknown[]) {
+      console.log(`[plugin:${id}]`, ...args);
+    },
+  };
+
+  return Object.assign(ctx, {
+    async dispose() {
+      const cleanupErrors: unknown[] = [];
+      for (const toolId of registeredTools) {
+        try {
+          runtime.toolRegistry.unregister(toolId);
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      registeredTools.clear();
+      for (const channel of registeredIpc) {
+        try {
+          runtime.unregisterIpc(channel);
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      registeredIpc.clear();
+      const adapterIds = Array.from(registeredAdapters);
+      registeredAdapters.clear();
+      const adapterResults = await Promise.allSettled(
+        adapterIds.map((adapterId) => runtime.channelManager.unregister(adapterId)),
+      );
+      for (const result of adapterResults) {
+        if (result.status === "rejected") cleanupErrors.push(result.reason);
+      }
+      if (cleanupErrors.length > 0) {
+        console.warn(`[plugin:${id}] 清理资源时发生 ${cleanupErrors.length} 个错误`, cleanupErrors);
+      }
+    },
+  });
+}

--- a/src/plugins/demo/index.ts
+++ b/src/plugins/demo/index.ts
@@ -1,0 +1,21 @@
+import type { CyrenePlugin } from "../types";
+
+export const demoPlugin: CyrenePlugin = {
+  register(ctx) {
+    ctx.registerTool({
+      id: "demo_hello",
+      name: "演示问候",
+      description: "返回一句来自演示插件的问候语",
+      enabled: true,
+      inputSchema: { type: "object", properties: {}, required: [] },
+      execute: async () => "来自演示插件的问候 👋",
+    });
+    ctx.registerIpc("ping", () => "pong");
+    ctx.log("演示插件已注册");
+  },
+  unregister() {
+    console.log("[plugin:demo] 演示插件已卸载");
+  },
+};
+
+export default demoPlugin;

--- a/src/plugins/demo/manifest.json
+++ b/src/plugins/demo/manifest.json
@@ -1,4 +1,5 @@
 {
+  "apiVersion": 1,
   "id": "demo",
   "name": "演示插件",
   "version": "0.1.0",

--- a/src/plugins/demo/manifest.json
+++ b/src/plugins/demo/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "demo",
+  "name": "演示插件",
+  "version": "0.1.0",
+  "description": "插件系统演示：注册一个工具与一个 IPC 通道",
+  "author": "liyi",
+  "entry": "index.js",
+  "defaultEnabled": false
+}

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -17,6 +17,7 @@ function fixture(rel: string, files: Record<string, string>): string {
 }
 
 const validManifest = {
+  apiVersion: 1,
   id: "demo",
   name: "演示",
   version: "1.0.0",
@@ -69,12 +70,25 @@ describe("readManifest", () => {
     expect(readManifest(dir)).toBeNull();
   });
 
-  it("非法 deps 值被过滤，仅保留白名单项", () => {
+  it("拒绝未知 deps，而不是静默过滤拼写错误", () => {
     const dir = fixture("bad-deps", {
       "manifest.json": JSON.stringify({ ...validManifest, deps: ["channels", "llm", "nope"] }),
       "index.cjs": `module.exports = { register() {} };`,
     });
-    expect(readManifest(dir)?.deps).toEqual(["channels", "llm"]);
+    expect(readManifest(dir)).toBeNull();
+  });
+
+  it("拒绝不兼容 apiVersion 和非 SemVer 版本", () => {
+    const badApi = fixture("bad-api", {
+      "manifest.json": JSON.stringify({ ...validManifest, apiVersion: 2 }),
+      "index.cjs": "module.exports = {};",
+    });
+    const badVersion = fixture("bad-version", {
+      "manifest.json": JSON.stringify({ ...validManifest, version: "latest" }),
+      "index.cjs": "module.exports = {};",
+    });
+    expect(readManifest(badApi)).toBeNull();
+    expect(readManifest(badVersion)).toBeNull();
   });
 });
 
@@ -89,6 +103,13 @@ describe("scanPluginDir", () => {
     fixture("root/no-manifest", { "x.txt": "x" });
     expect(scanPluginDir(root).map((r) => r.manifest.id)).toEqual(["demo"]);
   });
+
+  it("根路径不是目录时返回问题而不抛出", () => {
+    const file = fixture("not-a-root", { "file.txt": "x" });
+    const issues: string[] = [];
+    expect(scanPluginDir(path.join(file, "file.txt"), "user", (issue) => issues.push(issue.message))).toEqual([]);
+    expect(issues[0]).toMatch(/无法扫描插件目录/);
+  });
 });
 
 describe("loadPlugin", () => {
@@ -97,7 +118,7 @@ describe("loadPlugin", () => {
       "manifest.json": JSON.stringify(validManifest),
       "index.cjs": `module.exports = { register(ctx) { ctx.log("hi"); } };`,
     });
-    const record = { manifest: readManifest(dir)!, dir, enabled: true };
+    const record = scanPluginDir(path.dirname(dir)).find((item) => item.dir === dir)!;
     const plugin = await loadPlugin(record);
     expect(typeof plugin.register).toBe("function");
   });
@@ -107,7 +128,7 @@ describe("loadPlugin", () => {
       "manifest.json": JSON.stringify(validManifest),
       "index.cjs": `module.exports = {};`,
     });
-    const record = { manifest: readManifest(dir)!, dir, enabled: true };
+    const record = scanPluginDir(path.dirname(dir)).find((item) => item.dir === dir)!;
     await expect(loadPlugin(record)).rejects.toThrow(/register/);
   });
 });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPlugin, readManifest, scanPluginDir } from "./loader";
+
+let tmp: string;
+
+function fixture(rel: string, files: Record<string, string>): string {
+  if (!tmp) tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-plugins-test-"));
+  const dir = path.join(tmp, rel);
+  mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(path.join(dir, name), content, "utf8");
+  }
+  return dir;
+}
+
+const validManifest = {
+  id: "demo",
+  name: "演示",
+  version: "1.0.0",
+  description: "d",
+  author: "a",
+  entry: "index.cjs",
+  defaultEnabled: true,
+};
+
+afterEach(() => {
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = "";
+  }
+});
+
+describe("readManifest", () => {
+  it("读取合法 manifest", () => {
+    const dir = fixture("ok", {
+      "manifest.json": JSON.stringify(validManifest),
+      "index.cjs": "module.exports = {};",
+    });
+    expect(readManifest(dir)).toMatchObject({ id: "demo" });
+  });
+
+  it("拒绝非法 id 或缺失入口文件", () => {
+    const dir = fixture("bad", {
+      "manifest.json": JSON.stringify({ ...validManifest, id: "Bad ID", entry: "nope.js" }),
+    });
+    expect(readManifest(dir)).toBeNull();
+  });
+
+  it("无 manifest 返回 null", () => {
+    const dir = fixture("empty", { "readme.txt": "x" });
+    expect(readManifest(dir)).toBeNull();
+  });
+
+  it("拒绝带路径的 entry（防目录穿越）", () => {
+    const dir = fixture("bad-entry-path", {
+      "manifest.json": JSON.stringify({ ...validManifest, entry: "sub/index.js" }),
+    });
+    expect(readManifest(dir)).toBeNull();
+  });
+
+  it("拒绝非 JavaScript 入口", () => {
+    const dir = fixture("bad-entry-extension", {
+      "manifest.json": JSON.stringify({ ...validManifest, entry: "payload.json" }),
+      "payload.json": "{}",
+    });
+    expect(readManifest(dir)).toBeNull();
+  });
+
+  it("非法 deps 值被过滤，仅保留白名单项", () => {
+    const dir = fixture("bad-deps", {
+      "manifest.json": JSON.stringify({ ...validManifest, deps: ["channels", "llm", "nope"] }),
+      "index.cjs": `module.exports = { register() {} };`,
+    });
+    expect(readManifest(dir)?.deps).toEqual(["channels", "llm"]);
+  });
+});
+
+describe("scanPluginDir", () => {
+  it("只收集带合法 manifest 的一级子目录", () => {
+    const root = fixture("root", {});
+    fixture("root/ok", {
+      "manifest.json": JSON.stringify(validManifest),
+      "index.cjs": "module.exports = {};",
+    });
+    fixture("root/bad-json", { "manifest.json": "not json" });
+    fixture("root/no-manifest", { "x.txt": "x" });
+    expect(scanPluginDir(root).map((r) => r.manifest.id)).toEqual(["demo"]);
+  });
+});
+
+describe("loadPlugin", () => {
+  it("加载 CJS 插件并归一化 register", async () => {
+    const dir = fixture("cjs", {
+      "manifest.json": JSON.stringify(validManifest),
+      "index.cjs": `module.exports = { register(ctx) { ctx.log("hi"); } };`,
+    });
+    const record = { manifest: readManifest(dir)!, dir, enabled: true };
+    const plugin = await loadPlugin(record);
+    expect(typeof plugin.register).toBe("function");
+  });
+
+  it("入口未导出 register 抛错", async () => {
+    const dir = fixture("bad-entry", {
+      "manifest.json": JSON.stringify(validManifest),
+      "index.cjs": `module.exports = {};`,
+    });
+    const record = { manifest: readManifest(dir)!, dir, enabled: true };
+    await expect(loadPlugin(record)).rejects.toThrow(/register/);
+  });
+});

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,64 +1,171 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { CyrenePlugin, PluginManifest, PluginRecord } from "./types";
+import { CURRENT_PLUGIN_API_VERSION } from "./api";
+import type {
+  CyrenePlugin,
+  PluginCapability,
+  PluginManifest,
+  PluginRecord,
+  PluginSource,
+} from "./types";
 
 const MANIFEST_FILE = "manifest.json";
 const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 const DEPS_ALLOWED = new Set(["channels", "llm"]);
 const ENTRY_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
+let esmImportGeneration = 0;
 
-/** 读取并校验 manifest；不合法返回 null（调用方跳过并留痕日志） */
-export function readManifest(dir: string): PluginManifest | null {
+export interface PluginScanIssue {
+  root: string;
+  path?: string;
+  source: PluginSource;
+  message: string;
+}
+
+interface ManifestInspection {
+  manifest: PluginManifest | null;
+  error?: string;
+  fingerprint?: string;
+}
+
+function asErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function inspectManifest(dir: string): ManifestInspection {
   const manifestPath = path.join(dir, MANIFEST_FILE);
-  if (!existsSync(manifestPath)) return null;
+  if (!existsSync(manifestPath)) return { manifest: null, error: "缺少 manifest.json" };
   try {
-    const raw = JSON.parse(readFileSync(manifestPath, "utf8")) as PluginManifest;
-    if (!raw || typeof raw.id !== "string" || !ID_RE.test(raw.id)) return null;
-    if (typeof raw.name !== "string" || !raw.name) return null;
-    if (typeof raw.version !== "string" || !raw.version) return null;
-    if (typeof raw.description !== "string" || !raw.description) return null;
-    if (typeof raw.author !== "string" || !raw.author) return null;
-    if (typeof raw.entry !== "string" || !raw.entry) return null;
-    // entry 必须是目录内的裸文件名，拒绝 ../ 或子目录穿越
-    if (path.basename(raw.entry) !== raw.entry) return null;
-    if (!ENTRY_EXTENSIONS.has(path.extname(raw.entry).toLowerCase())) return null;
-    if (!existsSync(path.join(dir, raw.entry))) return null;
-    return {
+    const manifestText = readFileSync(manifestPath, "utf8");
+    const raw = JSON.parse(manifestText) as Partial<PluginManifest> | null;
+    if (!raw || typeof raw !== "object") return { manifest: null, error: "manifest 必须是对象" };
+    if (raw.apiVersion !== CURRENT_PLUGIN_API_VERSION) {
+      return {
+        manifest: null,
+        error: `不兼容的 apiVersion: ${String(raw.apiVersion)}（当前支持 ${CURRENT_PLUGIN_API_VERSION}）`,
+      };
+    }
+    if (typeof raw.id !== "string" || !ID_RE.test(raw.id)) {
+      return { manifest: null, error: "id 不符合小写连字符格式" };
+    }
+    if (typeof raw.name !== "string" || !raw.name.trim()) return { manifest: null, error: "name 不能为空" };
+    if (typeof raw.version !== "string" || !SEMVER_RE.test(raw.version)) {
+      return { manifest: null, error: "version 必须是合法 SemVer" };
+    }
+    if (typeof raw.description !== "string" || !raw.description.trim()) {
+      return { manifest: null, error: "description 不能为空" };
+    }
+    if (typeof raw.author !== "string" || !raw.author.trim()) return { manifest: null, error: "author 不能为空" };
+    if (typeof raw.entry !== "string" || !raw.entry) return { manifest: null, error: "entry 不能为空" };
+    if (path.basename(raw.entry) !== raw.entry) return { manifest: null, error: "entry 必须是插件目录内的裸文件名" };
+    if (!ENTRY_EXTENSIONS.has(path.extname(raw.entry).toLowerCase())) {
+      return { manifest: null, error: "entry 扩展名仅支持 .cjs/.js/.mjs" };
+    }
+    if (raw.defaultEnabled !== undefined && typeof raw.defaultEnabled !== "boolean") {
+      return { manifest: null, error: "defaultEnabled 必须是布尔值" };
+    }
+    let deps: PluginCapability[] | undefined;
+    if (raw.deps !== undefined) {
+      if (!Array.isArray(raw.deps)) return { manifest: null, error: "deps 必须是数组" };
+      if (raw.deps.some((dep) => typeof dep !== "string" || !DEPS_ALLOWED.has(dep))) {
+        return { manifest: null, error: "deps 包含未知主程序能力" };
+      }
+      deps = Array.from(new Set(raw.deps)) as PluginCapability[];
+    }
+
+    const entryPath = path.join(dir, raw.entry);
+    if (!existsSync(entryPath) || !statSync(entryPath).isFile()) {
+      return { manifest: null, error: `入口文件不存在: ${raw.entry}` };
+    }
+    const realDir = realpathSync(dir);
+    const realEntry = realpathSync(entryPath);
+    const relativeEntry = path.relative(realDir, realEntry);
+    if (relativeEntry.startsWith("..") || path.isAbsolute(relativeEntry)) {
+      return { manifest: null, error: "entry 不能通过链接指向插件目录外" };
+    }
+
+    const manifest: PluginManifest = {
+      apiVersion: CURRENT_PLUGIN_API_VERSION,
       id: raw.id,
-      name: raw.name,
+      name: raw.name.trim(),
       version: raw.version,
-      description: raw.description,
-      author: raw.author,
+      description: raw.description.trim(),
+      author: raw.author.trim(),
       entry: raw.entry,
       defaultEnabled: raw.defaultEnabled !== false,
-      deps: Array.isArray(raw.deps)
-        ? raw.deps.filter(
-            (d): d is "channels" | "llm" =>
-              typeof d === "string" && DEPS_ALLOWED.has(d),
-          )
-        : undefined,
+      deps,
     };
-  } catch {
-    return null;
+    const fingerprint = createHash("sha256")
+      .update(manifestText)
+      .update("\0")
+      .update(readFileSync(realEntry))
+      .digest("hex");
+    return { manifest, fingerprint };
+  } catch (error) {
+    return { manifest: null, error: asErrorMessage(error) };
   }
 }
 
+/** 读取并校验 manifest；不合法返回 null（调用方跳过并留痕日志） */
+export function readManifest(dir: string): PluginManifest | null {
+  return inspectManifest(dir).manifest;
+}
+
 /** 扫描 root 下所有一级子目录，收集带合法 manifest 的插件 */
-export function scanPluginDir(root: string): PluginRecord[] {
+export function scanPluginDir(
+  root: string,
+  source: PluginSource = "user",
+  onIssue?: (issue: PluginScanIssue) => void,
+): PluginRecord[] {
   if (!existsSync(root)) return [];
   const out: PluginRecord[] = [];
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
+  let entries: Dirent<string>[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch (error) {
+    const issue = { root, source, message: `无法扫描插件目录: ${asErrorMessage(error)}` } satisfies PluginScanIssue;
+    onIssue?.(issue);
+    console.warn(`[plugins] ${issue.message}: ${root}`);
+    return [];
+  }
+  for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const dir = path.join(root, entry.name);
-    const manifest = readManifest(dir);
-    if (!manifest) {
-      console.warn(`[plugins] 忽略无效插件目录: ${dir}`);
+    const inspected = inspectManifest(dir);
+    if (!inspected.manifest || !inspected.fingerprint) {
+      const issue = {
+        root,
+        path: dir,
+        source,
+        message: inspected.error ?? "无效 manifest",
+      } satisfies PluginScanIssue;
+      onIssue?.(issue);
+      console.warn(`[plugins] 忽略无效插件目录: ${dir} (${issue.message})`);
       continue;
     }
-    out.push({ manifest, dir });
+    out.push({
+      manifest: inspected.manifest,
+      dir,
+      source,
+      fingerprint: inspected.fingerprint,
+    });
   }
   return out;
+}
+
+/** Remove cached CommonJS modules owned by one plugin before reactivation. */
+export function clearPluginModuleCache(pluginDir: string): void {
+  const root = path.resolve(pluginDir);
+  for (const modulePath of Object.keys(require.cache)) {
+    const relative = path.relative(root, modulePath);
+    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+      delete require.cache[modulePath];
+    }
+  }
 }
 
 /** 动态加载插件入口（.cjs/.js/.mjs 均可），归一化 default/named export */
@@ -66,6 +173,7 @@ export async function loadPlugin(record: PluginRecord): Promise<CyrenePlugin> {
   const entry = path.join(record.dir, record.manifest.entry);
   const ext = path.extname(entry).toLowerCase();
   let mod: Record<string, unknown>;
+  clearPluginModuleCache(record.dir);
   if (ext === ".mjs") {
     // commonjs 编译会把 import() 改写为 require()，require 无法加载 file:// URL，
     // 因此 ESM 入口经运行时 import 加载（new Function 避开 tsc 改写）。
@@ -73,7 +181,13 @@ export async function loadPlugin(record: PluginRecord): Promise<CyrenePlugin> {
       "specifier",
       "return import(specifier)",
     ) as (specifier: string) => Promise<Record<string, unknown>>;
-    mod = await dynamicImport(pathToFileURL(entry).href);
+    const specifier = new URL(pathToFileURL(entry).href);
+    esmImportGeneration += 1;
+    specifier.searchParams.set(
+      "cyreneReload",
+      `${record.fingerprint}-${Date.now()}-${esmImportGeneration}`,
+    );
+    mod = await dynamicImport(specifier.href);
   } else {
     mod = require(entry) as Record<string, unknown>;
   }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { CyrenePlugin, PluginManifest, PluginRecord } from "./types";
+
+const MANIFEST_FILE = "manifest.json";
+const ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const DEPS_ALLOWED = new Set(["channels", "llm"]);
+const ENTRY_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
+
+/** 读取并校验 manifest；不合法返回 null（调用方跳过并留痕日志） */
+export function readManifest(dir: string): PluginManifest | null {
+  const manifestPath = path.join(dir, MANIFEST_FILE);
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf8")) as PluginManifest;
+    if (!raw || typeof raw.id !== "string" || !ID_RE.test(raw.id)) return null;
+    if (typeof raw.name !== "string" || !raw.name) return null;
+    if (typeof raw.version !== "string" || !raw.version) return null;
+    if (typeof raw.description !== "string" || !raw.description) return null;
+    if (typeof raw.author !== "string" || !raw.author) return null;
+    if (typeof raw.entry !== "string" || !raw.entry) return null;
+    // entry 必须是目录内的裸文件名，拒绝 ../ 或子目录穿越
+    if (path.basename(raw.entry) !== raw.entry) return null;
+    if (!ENTRY_EXTENSIONS.has(path.extname(raw.entry).toLowerCase())) return null;
+    if (!existsSync(path.join(dir, raw.entry))) return null;
+    return {
+      id: raw.id,
+      name: raw.name,
+      version: raw.version,
+      description: raw.description,
+      author: raw.author,
+      entry: raw.entry,
+      defaultEnabled: raw.defaultEnabled !== false,
+      deps: Array.isArray(raw.deps)
+        ? raw.deps.filter(
+            (d): d is "channels" | "llm" =>
+              typeof d === "string" && DEPS_ALLOWED.has(d),
+          )
+        : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** 扫描 root 下所有一级子目录，收集带合法 manifest 的插件 */
+export function scanPluginDir(root: string): PluginRecord[] {
+  if (!existsSync(root)) return [];
+  const out: PluginRecord[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(root, entry.name);
+    const manifest = readManifest(dir);
+    if (!manifest) {
+      console.warn(`[plugins] 忽略无效插件目录: ${dir}`);
+      continue;
+    }
+    out.push({ manifest, dir });
+  }
+  return out;
+}
+
+/** 动态加载插件入口（.cjs/.js/.mjs 均可），归一化 default/named export */
+export async function loadPlugin(record: PluginRecord): Promise<CyrenePlugin> {
+  const entry = path.join(record.dir, record.manifest.entry);
+  const ext = path.extname(entry).toLowerCase();
+  let mod: Record<string, unknown>;
+  if (ext === ".mjs") {
+    // commonjs 编译会把 import() 改写为 require()，require 无法加载 file:// URL，
+    // 因此 ESM 入口经运行时 import 加载（new Function 避开 tsc 改写）。
+    const dynamicImport = new Function(
+      "specifier",
+      "return import(specifier)",
+    ) as (specifier: string) => Promise<Record<string, unknown>>;
+    mod = await dynamicImport(pathToFileURL(entry).href);
+  } else {
+    mod = require(entry) as Record<string, unknown>;
+  }
+  const plugin = (mod.default ?? mod) as Partial<CyrenePlugin>;
+  if (typeof plugin.register !== "function") {
+    throw new Error(`插件 ${record.manifest.id} 入口未导出 register()`);
+  }
+  return plugin as CyrenePlugin;
+}

--- a/src/plugins/manager.test.ts
+++ b/src/plugins/manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +14,7 @@ function fixturePlugin(id: string, manifestId: string = id): string {
   writeFileSync(
     path.join(dir, "manifest.json"),
     JSON.stringify({
+      apiVersion: 1,
       id: manifestId,
       name: id,
       version: "1.0.0",
@@ -61,7 +62,7 @@ function harness(overrides: Partial<PluginManagerOptions> = {}) {
   };
   let enabledMap: Record<string, boolean> = {};
   const options: PluginManagerOptions = {
-    scanRoots: [path.dirname(fixturePlugin("demo"))],
+    scanRoots: [{ path: path.dirname(fixturePlugin("demo")), source: "builtin" }],
     storageRoot: path.join(tmp ?? "tmp", "storage"),
     runtime,
     loadEnabledMap: () => ({ ...enabledMap }),
@@ -81,6 +82,11 @@ describe("PluginManager", () => {
     expect(mgr.list().map((e) => e.id)).toEqual(["demo"]);
     expect(mgr.list()[0].enabled).toBe(true);
     expect(h.ipc.has("plugins:list")).toBe(true);
+    expect(h.ipc.has("plugins:rescan")).toBe(true);
+    expect(h.ipc.get("plugins:list")?.()).toMatchObject({
+      plugins: [expect.objectContaining({ id: "demo", status: "running" })],
+      issues: [],
+    });
     expect(h.ipc.has("plugins:set-enabled")).toBe(true);
     expect(h.ipc.has("plugin:demo:ping")).toBe(true);
   });
@@ -130,7 +136,7 @@ describe("PluginManager", () => {
   it("重复 id 只保留第一个扫描结果", async () => {
     const h = harness();
     fixturePlugin("demo-copy", "demo");
-    h.options.scanRoots = [path.dirname(fixturePlugin("demo"))];
+    h.options.scanRoots = [{ path: path.dirname(fixturePlugin("demo")), source: "builtin" }];
     const mgr = new PluginManager(h.options);
     await mgr.start();
     expect(mgr.list()).toHaveLength(1);
@@ -175,7 +181,7 @@ describe("PluginManager", () => {
     expect(h.getEnabledMap().demo).toBe(false);
   });
 
-  it("启动失败后显示停用；再次启用会重试", async () => {
+  it("启动失败后保留 desired state 和错误；修复入口后可重试", async () => {
     const h = harness();
     writeFileSync(
       path.join(tmp, "demo", "index.cjs"),
@@ -192,10 +198,113 @@ describe("PluginManager", () => {
 
     await mgr.start();
     expect(mgr.list()[0].enabled).toBe(false);
+    expect(mgr.list()[0]).toMatchObject({
+      configuredEnabled: true,
+      status: "failed",
+      error: "first start failed",
+    });
+
+    writeFileSync(
+      path.join(tmp, "demo", "index.cjs"),
+      `module.exports = { register(ctx) { ctx.registerIpc("ping", () => "pong"); } };`,
+      "utf8",
+    );
 
     const retried = await mgr.setEnabled("demo", true);
     expect(retried.ok).toBe(true);
     expect(mgr.list()[0].enabled).toBe(true);
     expect(h.ipc.has("plugin:demo:ping")).toBe(true);
+  });
+
+  it("register 失败时调用插件 unregister 回滚，再释放宿主资源", async () => {
+    const h = harness();
+    const rollbackMarker = path.join(tmp, "rollback-called");
+    writeFileSync(
+      path.join(tmp, "demo", "index.cjs"),
+      `const fs = require("node:fs");
+      module.exports = {
+        register(ctx) {
+          ctx.registerIpc("partial", () => "leaked");
+          throw new Error("partial activation failed");
+        },
+        unregister() { fs.writeFileSync(${JSON.stringify(rollbackMarker)}, "yes"); }
+      };`,
+      "utf8",
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    expect(existsSync(rollbackMarker)).toBe(true);
+    expect(h.ipc.has("plugin:demo:partial")).toBe(false);
+    expect(mgr.list()[0]).toMatchObject({
+      configuredEnabled: true,
+      enabled: false,
+      status: "failed",
+      error: "partial activation failed",
+    });
+  });
+
+  it("用户插件首次发现时忽略作者的 defaultEnabled，等待用户确认", async () => {
+    const h = harness();
+    h.options.scanRoots = [{ path: path.dirname(fixturePlugin("demo")), source: "user" }];
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(mgr.list()[0]).toMatchObject({
+      source: "user",
+      configuredEnabled: false,
+      status: "disabled",
+    });
+    expect(h.tools).toEqual([]);
+  });
+
+  it("rescan 重新加载活动插件并清理删除的插件", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(h.ipc.get("plugin:demo:ping")?.()).toBe("pong");
+
+    writeFileSync(
+      path.join(tmp, "demo", "index.cjs"),
+      `module.exports = { register(ctx) {
+        ctx.registerIpc("ping", () => "v2");
+        ctx.registerTool({ id: "demo_tool", name: "t", description: "d", enabled: true, inputSchema: { type: "object", properties: {}, required: [] }, execute: async () => "ok" });
+      } };`,
+      "utf8",
+    );
+    await mgr.rescan();
+    expect(h.ipc.get("plugin:demo:ping")?.()).toBe("v2");
+    expect(h.tools).toEqual(["demo_tool"]);
+
+    rmSync(path.join(tmp, "demo"), { recursive: true, force: true });
+    await mgr.rescan();
+    expect(mgr.list()).toEqual([]);
+    expect(h.tools).toEqual([]);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(false);
+  });
+
+  it("并发启用请求串行执行，不重复注册资源", async () => {
+    const h = harness({ loadEnabledMap: () => ({ demo: false }) });
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    const [first, second] = await Promise.all([
+      mgr.setEnabled("demo", true),
+      mgr.setEnabled("demo", true),
+    ]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(h.tools).toEqual(["demo_tool"]);
+  });
+
+  it("扫描根目录不可读时保留应用可用并展示问题", async () => {
+    const h = harness();
+    const invalidRoot = path.join(tmp, "not-a-directory");
+    writeFileSync(invalidRoot, "x", "utf8");
+    h.options.scanRoots = [{ path: invalidRoot, source: "user" }];
+    const mgr = new PluginManager(h.options);
+    await expect(mgr.start()).resolves.toBeUndefined();
+    expect(mgr.overview().plugins).toEqual([]);
+    expect(mgr.overview().issues[0]?.message).toMatch(/无法扫描插件目录/);
   });
 });

--- a/src/plugins/manager.test.ts
+++ b/src/plugins/manager.test.ts
@@ -83,6 +83,7 @@ describe("PluginManager", () => {
     expect(mgr.list()[0].enabled).toBe(true);
     expect(h.ipc.has("plugins:list")).toBe(true);
     expect(h.ipc.has("plugins:rescan")).toBe(true);
+    expect(h.ipc.has("plugins:uninstall")).toBe(true);
     expect(h.ipc.get("plugins:list")?.()).toMatchObject({
       plugins: [expect.objectContaining({ id: "demo", status: "running" })],
       issues: [],
@@ -256,6 +257,75 @@ describe("PluginManager", () => {
       configuredEnabled: false,
       status: "disabled",
     });
+    expect(h.tools).toEqual([]);
+  });
+
+  it("卸载用户插件时先清理运行资源，再删除目录、启停记录并重扫", async () => {
+    const h = harness({ loadEnabledMap: () => ({ demo: true }) });
+    h.options.scanRoots = [{ path: path.dirname(fixturePlugin("demo")), source: "user" }];
+    const pluginDir = path.join(tmp, "demo");
+    const pluginDataDir = path.join(h.options.storageRoot, "demo");
+    mkdirSync(pluginDataDir, { recursive: true });
+    writeFileSync(path.join(pluginDataDir, "settings.json"), "{}", "utf8");
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(h.tools).toContain("demo_tool");
+
+    const result = await mgr.uninstall("demo");
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(pluginDir)).toBe(false);
+    expect(existsSync(pluginDataDir)).toBe(true);
+    expect(h.tools).toEqual([]);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(false);
+    expect(h.getEnabledMap()).toEqual({});
+    expect(mgr.list()).toEqual([]);
+  });
+
+  it("拒绝卸载内置插件", async () => {
+    const h = harness();
+    const pluginDir = path.join(tmp, "demo");
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    const result = await mgr.uninstall("demo");
+
+    expect(result).toEqual({ ok: false, error: "内置插件不能卸载: demo" });
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(mgr.list()).toHaveLength(1);
+  });
+
+  it("用户插件记录不再位于配置的用户根目录时拒绝删除", async () => {
+    const h = harness({ loadEnabledMap: () => ({ demo: true }) });
+    const pluginDir = path.join(tmp, "demo");
+    h.options.scanRoots = [{ path: path.dirname(pluginDir), source: "user" }];
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    h.options.scanRoots = [{ path: path.join(tmp, "different-root"), source: "user" }];
+
+    const result = await mgr.uninstall("demo");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("拒绝卸载不安全的插件路径");
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(h.tools).toContain("demo_tool");
+  });
+
+  it("启停记录无法持久化时不删除用户插件目录", async () => {
+    const h = harness({
+      loadEnabledMap: () => ({ demo: true }),
+      saveEnabledMap: () => { throw new Error("disk read-only"); },
+    });
+    const pluginDir = path.join(tmp, "demo");
+    h.options.scanRoots = [{ path: path.dirname(pluginDir), source: "user" }];
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    const result = await mgr.uninstall("demo");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("清理插件启停记录失败，未删除目录");
+    expect(existsSync(pluginDir)).toBe(true);
     expect(h.tools).toEqual([]);
   });
 

--- a/src/plugins/manager.test.ts
+++ b/src/plugins/manager.test.ts
@@ -1,0 +1,201 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PluginManager, type PluginManagerOptions } from "./manager";
+import type { PluginRuntime } from "./context";
+
+let tmp: string;
+
+function fixturePlugin(id: string, manifestId: string = id): string {
+  if (!tmp) tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-mgr-test-"));
+  const dir = path.join(tmp, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "manifest.json"),
+    JSON.stringify({
+      id: manifestId,
+      name: id,
+      version: "1.0.0",
+      description: "d",
+      author: "a",
+      entry: "index.cjs",
+      defaultEnabled: true,
+    }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(dir, "index.cjs"),
+    `module.exports = { open() {}, register(ctx) {
+      ctx.registerIpc("ping", () => "pong");
+      ctx.registerTool({ id: "${id}_tool", name: "t", description: "d", enabled: true, inputSchema: { type: "object", properties: {}, required: [] }, execute: async () => "ok" });
+    }, unregister() {} };`,
+    "utf8",
+  );
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = "";
+  }
+});
+
+function harness(overrides: Partial<PluginManagerOptions> = {}) {
+  const tools: string[] = [];
+  const ipc = new Map<string, (...args: unknown[]) => unknown>();
+  const runtime: PluginRuntime = {
+    toolRegistry: {
+      register: (t) => tools.push(t.id),
+      unregister: (id) => {
+        const i = tools.indexOf(id);
+        if (i >= 0) tools.splice(i, 1);
+        return true;
+      },
+    },
+    channelManager: { has: () => false, register: () => {}, unregister: async () => true, startOne: async () => {} },
+    registerIpc: (c, h) => ipc.set(c, h),
+    unregisterIpc: (c) => ipc.delete(c),
+  };
+  let enabledMap: Record<string, boolean> = {};
+  const options: PluginManagerOptions = {
+    scanRoots: [path.dirname(fixturePlugin("demo"))],
+    storageRoot: path.join(tmp ?? "tmp", "storage"),
+    runtime,
+    loadEnabledMap: () => ({ ...enabledMap }),
+    saveEnabledMap: (m) => {
+      enabledMap = { ...m };
+    },
+    ...overrides,
+  };
+  return { options, tools, ipc, getEnabledMap: () => ({ ...enabledMap }) };
+}
+
+describe("PluginManager", () => {
+  it("启动时启用 defaultEnabled 插件并注册列表/开关 IPC", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(mgr.list().map((e) => e.id)).toEqual(["demo"]);
+    expect(mgr.list()[0].enabled).toBe(true);
+    expect(h.ipc.has("plugins:list")).toBe(true);
+    expect(h.ipc.has("plugins:set-enabled")).toBe(true);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(true);
+  });
+
+  it("只允许打开已启用且声明 open 的插件", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    expect(mgr.list()[0].canOpen).toBe(true);
+    expect(h.ipc.has("plugins:open")).toBe(true);
+    await expect(h.ipc.get("plugins:open")?.("demo")).resolves.toEqual({ ok: true });
+
+    await mgr.setEnabled("demo", false);
+    await expect(h.ipc.get("plugins:open")?.("demo")).resolves.toMatchObject({ ok: false });
+  });
+
+  it("开关关闭的插件不激活", async () => {
+    const h = harness({
+      loadEnabledMap: () => ({ demo: false }),
+    });
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(mgr.list()[0].enabled).toBe(false);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(false);
+  });
+
+  it("setEnabled(false) 清理资源并持久化；setEnabled(true) 重新激活", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(h.tools).toContain("demo_tool");
+
+    const off = await mgr.setEnabled("demo", false);
+    expect(off.ok).toBe(true);
+    expect(mgr.list()[0].enabled).toBe(false);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(false);
+    expect(h.tools).toEqual([]);
+    expect(h.getEnabledMap().demo).toBe(false);
+
+    const on = await mgr.setEnabled("demo", true);
+    expect(on.ok).toBe(true);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(true);
+    expect(h.tools).toContain("demo_tool");
+  });
+
+  it("重复 id 只保留第一个扫描结果", async () => {
+    const h = harness();
+    fixturePlugin("demo-copy", "demo");
+    h.options.scanRoots = [path.dirname(fixturePlugin("demo"))];
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    expect(mgr.list()).toHaveLength(1);
+  });
+
+  it("setEnabled 未知 id 返回失败", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+    const res = await mgr.setEnabled("nope", true);
+    expect(res.ok).toBe(false);
+  });
+
+  it("stop 清理插件资源和管理 IPC", async () => {
+    const h = harness();
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    await mgr.stop();
+
+    expect(mgr.list()).toEqual([]);
+    expect(h.tools).toEqual([]);
+    expect(h.ipc.size).toBe(0);
+  });
+
+  it("unregister 抛错时仍完成停用并持久化状态", async () => {
+    const h = harness();
+    writeFileSync(
+      path.join(tmp, "demo", "index.cjs"),
+      `module.exports = { register(ctx) { ctx.registerIpc("ping", () => "pong"); }, unregister() { throw new Error("cleanup failed"); } };`,
+      "utf8",
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mgr = new PluginManager(h.options);
+    await mgr.start();
+
+    const result = await mgr.setEnabled("demo", false);
+
+    expect(result).toEqual({ ok: true });
+    expect(mgr.list()[0].enabled).toBe(false);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(false);
+    expect(h.getEnabledMap().demo).toBe(false);
+  });
+
+  it("启动失败后显示停用；再次启用会重试", async () => {
+    const h = harness();
+    writeFileSync(
+      path.join(tmp, "demo", "index.cjs"),
+      `let attempts = 0;
+      module.exports = { register(ctx) {
+        attempts += 1;
+        if (attempts === 1) throw new Error("first start failed");
+        ctx.registerIpc("ping", () => "pong");
+      } };`,
+      "utf8",
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const mgr = new PluginManager(h.options);
+
+    await mgr.start();
+    expect(mgr.list()[0].enabled).toBe(false);
+
+    const retried = await mgr.setEnabled("demo", true);
+    expect(retried.ok).toBe(true);
+    expect(mgr.list()[0].enabled).toBe(true);
+    expect(h.ipc.has("plugin:demo:ping")).toBe(true);
+  });
+});

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
+import { lstat, realpath, rm } from "node:fs/promises";
 import { IPC } from "../shared/ipc-channels";
 import { createContext, type PluginRuntime } from "./context";
-import { loadPlugin, scanPluginDir, type PluginScanIssue } from "./loader";
+import {
+  clearPluginModuleCache,
+  loadPlugin,
+  scanPluginDir,
+  type PluginScanIssue,
+} from "./loader";
 import type {
   CyrenePlugin,
   PluginContext,
@@ -138,6 +144,12 @@ export class PluginManager {
         return this.open(id);
       });
       this.opts.runtime.registerIpc(IPC.PLUGINS_RESCAN, () => this.rescan());
+      this.opts.runtime.registerIpc(IPC.PLUGINS_UNINSTALL, (id: unknown) => {
+        if (typeof id !== "string" || !id) {
+          return { ok: false, error: "id 必须是非空字符串" };
+        }
+        return this.uninstall(id);
+      });
       await this.doRescan(false);
       this.opts.onListChanged?.();
     });
@@ -207,6 +219,55 @@ export class PluginManager {
     });
   }
 
+  uninstall(id: string): Promise<{ ok: boolean; error?: string; overview?: PluginOverview }> {
+    return this.enqueueOperation(async () => {
+      const record = this.records.get(id);
+      if (!record) return { ok: false, error: `插件不存在: ${id}` };
+      if (record.source !== "user") {
+        return { ok: false, error: `内置插件不能卸载: ${id}` };
+      }
+
+      try {
+        await this.assertSafeUserPluginDirectory(record);
+      } catch (error) {
+        return { ok: false, error: `拒绝卸载不安全的插件路径: ${errorMessage(error)}` };
+      }
+
+      await this.deactivate(id);
+
+      // 先持久化“未启用”语义。即使随后目录删除失败，下一次扫描也不会自动重启插件。
+      const nextEnabledMap = { ...this.enabledMap };
+      delete nextEnabledMap[id];
+      try {
+        this.opts.saveEnabledMap(nextEnabledMap);
+        this.enabledMap = nextEnabledMap;
+      } catch (error) {
+        const message = `清理插件启停记录失败，未删除目录: ${errorMessage(error)}`;
+        this.statuses.set(id, "failed");
+        this.errors.set(id, message);
+        this.opts.onListChanged?.();
+        return { ok: false, error: message };
+      }
+
+      try {
+        // unregister() 属于第三方代码，执行后再次校验，避免它在清理阶段替换目标目录。
+        await this.assertSafeUserPluginDirectory(record);
+        clearPluginModuleCache(record.dir);
+        await rm(record.dir, { recursive: true, force: false });
+      } catch (error) {
+        const message = `删除插件目录失败: ${errorMessage(error)}`;
+        this.statuses.set(id, "disabled");
+        this.errors.set(id, message);
+        this.opts.onListChanged?.();
+        return { ok: false, error: message };
+      }
+
+      await this.doRescan(false);
+      this.opts.onListChanged?.();
+      return { ok: true, overview: this.overview() };
+    });
+  }
+
   stop(): Promise<void> {
     return this.enqueueOperation(async () => {
       if (!this.started) return;
@@ -218,6 +279,7 @@ export class PluginManager {
         IPC.PLUGINS_SET_ENABLED,
         IPC.PLUGINS_OPEN,
         IPC.PLUGINS_RESCAN,
+        IPC.PLUGINS_UNINSTALL,
       ]) {
         try {
           this.opts.runtime.unregisterIpc(channel);
@@ -248,6 +310,37 @@ export class PluginManager {
     }
     // User-installed code is never executed on first discovery without opt-in.
     return record.source === "builtin" && record.manifest.defaultEnabled;
+  }
+
+  private async assertSafeUserPluginDirectory(record: PluginRecord): Promise<void> {
+    const candidateRoot = this.opts.scanRoots.find((root) => {
+      if (root.source !== "user") return false;
+      const relative = path.relative(path.resolve(root.path), path.resolve(record.dir));
+      return relative.length > 0
+        && !relative.startsWith("..")
+        && !path.isAbsolute(relative)
+        && !relative.includes(path.sep);
+    });
+    if (!candidateRoot) throw new Error("插件目录不是用户插件根目录的一级子目录");
+
+    const stat = await lstat(record.dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("插件路径不是普通目录");
+    }
+
+    const [rootReal, pluginReal] = await Promise.all([
+      realpath(candidateRoot.path),
+      realpath(record.dir),
+    ]);
+    const relative = path.relative(rootReal, pluginReal);
+    if (
+      relative.length === 0
+      || relative.startsWith("..")
+      || path.isAbsolute(relative)
+      || relative.includes(path.sep)
+    ) {
+      throw new Error("插件真实路径不在用户插件根目录的一级范围内");
+    }
   }
 
   private scanAll(): {

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -1,0 +1,184 @@
+import path from "node:path";
+import { IPC } from "../shared/ipc-channels";
+import { createContext, type PluginRuntime } from "./context";
+import { loadPlugin, scanPluginDir } from "./loader";
+import type { CyrenePlugin, PluginContext, PluginRecord } from "./types";
+
+export interface PluginListEntry {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  entry: string;
+  defaultEnabled: boolean;
+  enabled: boolean;
+  hasUnregister: boolean;
+  canOpen: boolean;
+}
+
+export interface PluginManagerOptions {
+  /** 插件扫描根目录（内置 + 用户目录） */
+  scanRoots: string[];
+  /** 插件私有存储根目录（userData/plugin-data） */
+  storageRoot: string;
+  runtime: PluginRuntime;
+  loadEnabledMap: () => Record<string, boolean>;
+  saveEnabledMap: (map: Record<string, boolean>) => void;
+  /** 列表/开关变化后回调（设置面板刷新用，可空） */
+  onListChanged?: () => void;
+}
+
+type DisposableContext = PluginContext & { dispose(): Promise<void> };
+
+export class PluginManager {
+  private records = new Map<string, PluginRecord>();
+  private instances = new Map<string, CyrenePlugin>();
+  private contexts = new Map<string, DisposableContext>();
+  private enabledMap: Record<string, boolean>;
+
+  constructor(private opts: PluginManagerOptions) {
+    this.enabledMap = opts.loadEnabledMap() ?? {};
+  }
+
+  list(): PluginListEntry[] {
+    return Array.from(this.records.values()).map((r) => {
+      const plugin = this.instances.get(r.manifest.id);
+      return {
+        id: r.manifest.id,
+        name: r.manifest.name,
+        version: r.manifest.version,
+        description: r.manifest.description,
+        author: r.manifest.author,
+        entry: r.manifest.entry,
+        defaultEnabled: r.manifest.defaultEnabled,
+        enabled: this.instances.has(r.manifest.id),
+        hasUnregister: typeof plugin?.unregister === "function",
+        canOpen: typeof plugin?.open === "function",
+      };
+    });
+  }
+
+  async start(): Promise<void> {
+    for (const root of this.opts.scanRoots) {
+      for (const record of scanPluginDir(root)) {
+        if (this.records.has(record.manifest.id)) {
+          console.warn(`[plugins] 插件 id 重复，忽略 ${record.dir}`);
+          continue;
+        }
+        this.records.set(record.manifest.id, record);
+      }
+    }
+    for (const [id] of this.records) {
+      const enabled = this.enabledMap[id] ?? this.records.get(id)!.manifest.defaultEnabled;
+      if (!enabled) continue;
+      try {
+        await this.activate(id);
+      } catch (err) {
+        console.error(`[plugins] 插件 ${id} 启用失败，跳过`, err);
+      }
+    }
+    this.opts.runtime.registerIpc(IPC.PLUGINS_LIST, () => this.list());
+    this.opts.runtime.registerIpc(IPC.PLUGINS_SET_ENABLED, async (id: unknown, enabled: unknown) => {
+      if (typeof enabled !== "boolean") {
+        return { ok: false, error: "enabled 必须是布尔值" };
+      }
+      return this.setEnabled(String(id), enabled);
+    });
+    this.opts.runtime.registerIpc(IPC.PLUGINS_OPEN, (id: unknown) => this.open(String(id)));
+    this.opts.onListChanged?.();
+  }
+
+  async setEnabled(
+    id: string,
+    enabled: boolean,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const record = this.records.get(id);
+    if (!record) return { ok: false, error: `插件不存在: ${id}` };
+    const running = this.instances.has(id);
+    if (running === enabled) return { ok: true };
+    try {
+      if (enabled) await this.activate(id);
+      else await this.deactivate(id);
+      this.enabledMap[id] = enabled;
+      this.opts.saveEnabledMap({ ...this.enabledMap });
+      this.opts.onListChanged?.();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  async open(id: string): Promise<{ ok: boolean; error?: string }> {
+    const plugin = this.instances.get(id);
+    if (!plugin) return { ok: false, error: `插件未启用: ${id}` };
+    if (!plugin.open) return { ok: false, error: `插件不支持打开窗口: ${id}` };
+    try {
+      await plugin.open();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const id of Array.from(this.instances.keys())) {
+      try {
+        await this.deactivate(id);
+      } catch (err) {
+        console.warn(`[plugins] 插件 ${id} 停止失败，继续清理其他插件`, err);
+      }
+    }
+    for (const channel of [IPC.PLUGINS_LIST, IPC.PLUGINS_SET_ENABLED, IPC.PLUGINS_OPEN]) {
+      try {
+        this.opts.runtime.unregisterIpc(channel);
+      } catch (err) {
+        console.warn(`[plugins] 管理通道 ${channel} 清理失败`, err);
+      }
+    }
+    this.records.clear();
+  }
+
+  private async activate(id: string): Promise<void> {
+    const record = this.records.get(id);
+    if (!record || this.instances.has(id)) return;
+    const plugin = await loadPlugin(record);
+    const ctx = createContext(
+      id,
+      path.join(this.opts.storageRoot, id),
+      this.opts.runtime,
+      record.manifest.deps,
+    );
+    try {
+      await plugin.register(ctx);
+    } catch (err) {
+      // register 抛错时立即释放已注册资源，避免泄漏
+      await ctx.dispose();
+      throw err;
+    }
+    this.instances.set(id, plugin);
+    this.contexts.set(id, ctx);
+    console.log(`[plugins] 已启用 ${id}@${record.manifest.version}`);
+  }
+
+  private async deactivate(id: string): Promise<void> {
+    const plugin = this.instances.get(id);
+    try {
+      if (plugin?.unregister) {
+        try {
+          await plugin.unregister();
+        } catch (err) {
+          console.warn(`[plugins] 插件 ${id} unregister 失败，继续释放框架资源`, err);
+        }
+      }
+    } finally {
+      try {
+        await this.contexts.get(id)?.dispose();
+      } finally {
+        this.instances.delete(id);
+        this.contexts.delete(id);
+      }
+    }
+    console.log(`[plugins] 已禁用 ${id}`);
+  }
+}

--- a/src/plugins/manager.ts
+++ b/src/plugins/manager.ts
@@ -1,8 +1,20 @@
 import path from "node:path";
 import { IPC } from "../shared/ipc-channels";
 import { createContext, type PluginRuntime } from "./context";
-import { loadPlugin, scanPluginDir } from "./loader";
-import type { CyrenePlugin, PluginContext, PluginRecord } from "./types";
+import { loadPlugin, scanPluginDir, type PluginScanIssue } from "./loader";
+import type {
+  CyrenePlugin,
+  PluginContext,
+  PluginRecord,
+  PluginSource,
+} from "./types";
+
+export type PluginRuntimeStatus =
+  | "disabled"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "failed";
 
 export interface PluginListEntry {
   id: string;
@@ -11,174 +23,380 @@ export interface PluginListEntry {
   description: string;
   author: string;
   entry: string;
+  apiVersion: number;
+  source: PluginSource;
+  path: string;
   defaultEnabled: boolean;
+  /** Desired persisted state, distinct from whether activation succeeded. */
+  configuredEnabled: boolean;
+  /** Backward-compatible running flag. */
   enabled: boolean;
+  status: PluginRuntimeStatus;
+  error?: string;
   hasUnregister: boolean;
   canOpen: boolean;
 }
 
+export interface PluginOverview {
+  plugins: PluginListEntry[];
+  issues: PluginScanIssue[];
+}
+
+export interface PluginScanRoot {
+  path: string;
+  source: PluginSource;
+}
+
 export interface PluginManagerOptions {
-  /** 插件扫描根目录（内置 + 用户目录） */
-  scanRoots: string[];
-  /** 插件私有存储根目录（userData/plugin-data） */
+  scanRoots: PluginScanRoot[];
+  /** Plugin-private data root (userData/plugin-data). */
   storageRoot: string;
   runtime: PluginRuntime;
   loadEnabledMap: () => Record<string, boolean>;
   saveEnabledMap: (map: Record<string, boolean>) => void;
-  /** 列表/开关变化后回调（设置面板刷新用，可空） */
   onListChanged?: () => void;
 }
 
 type DisposableContext = PluginContext & { dispose(): Promise<void> };
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export class PluginManager {
   private records = new Map<string, PluginRecord>();
   private instances = new Map<string, CyrenePlugin>();
   private contexts = new Map<string, DisposableContext>();
+  private statuses = new Map<string, PluginRuntimeStatus>();
+  private errors = new Map<string, string>();
+  private scanIssues: PluginScanIssue[] = [];
   private enabledMap: Record<string, boolean>;
+  private started = false;
+  /** All lifecycle mutations are serialized to prevent enable/disable/rescan races. */
+  private operationTail: Promise<void> = Promise.resolve();
 
   constructor(private opts: PluginManagerOptions) {
     this.enabledMap = opts.loadEnabledMap() ?? {};
   }
 
   list(): PluginListEntry[] {
-    return Array.from(this.records.values()).map((r) => {
-      const plugin = this.instances.get(r.manifest.id);
-      return {
-        id: r.manifest.id,
-        name: r.manifest.name,
-        version: r.manifest.version,
-        description: r.manifest.description,
-        author: r.manifest.author,
-        entry: r.manifest.entry,
-        defaultEnabled: r.manifest.defaultEnabled,
-        enabled: this.instances.has(r.manifest.id),
-        hasUnregister: typeof plugin?.unregister === "function",
-        canOpen: typeof plugin?.open === "function",
-      };
-    });
+    return Array.from(this.records.values())
+      .map((record) => {
+        const id = record.manifest.id;
+        const plugin = this.instances.get(id);
+        const status = this.statuses.get(id) ?? "disabled";
+        return {
+          id,
+          name: record.manifest.name,
+          version: record.manifest.version,
+          description: record.manifest.description,
+          author: record.manifest.author,
+          entry: record.manifest.entry,
+          apiVersion: record.manifest.apiVersion,
+          source: record.source,
+          path: record.dir,
+          defaultEnabled: record.manifest.defaultEnabled,
+          configuredEnabled: this.isConfiguredEnabled(record),
+          enabled: status === "running",
+          status,
+          error: this.errors.get(id),
+          hasUnregister: typeof plugin?.unregister === "function",
+          canOpen: typeof plugin?.open === "function",
+        };
+      })
+      .sort((a, b) => {
+        if (a.source !== b.source) return a.source === "builtin" ? -1 : 1;
+        return a.name.localeCompare(b.name, "zh-CN");
+      });
   }
 
-  async start(): Promise<void> {
-    for (const root of this.opts.scanRoots) {
-      for (const record of scanPluginDir(root)) {
-        if (this.records.has(record.manifest.id)) {
-          console.warn(`[plugins] 插件 id 重复，忽略 ${record.dir}`);
-          continue;
+  overview(): PluginOverview {
+    return { plugins: this.list(), issues: [...this.scanIssues] };
+  }
+
+  start(): Promise<void> {
+    return this.enqueueOperation(async () => {
+      if (this.started) return;
+      this.started = true;
+      this.opts.runtime.registerIpc(IPC.PLUGINS_LIST, () => this.overview());
+      this.opts.runtime.registerIpc(
+        IPC.PLUGINS_SET_ENABLED,
+        async (id: unknown, enabled: unknown) => {
+          if (typeof id !== "string" || !id) {
+            return { ok: false, error: "id 必须是非空字符串" };
+          }
+          if (typeof enabled !== "boolean") {
+            return { ok: false, error: "enabled 必须是布尔值" };
+          }
+          return this.setEnabled(id, enabled);
+        },
+      );
+      this.opts.runtime.registerIpc(IPC.PLUGINS_OPEN, (id: unknown) => {
+        if (typeof id !== "string" || !id) {
+          return { ok: false, error: "id 必须是非空字符串" };
         }
-        this.records.set(record.manifest.id, record);
-      }
-    }
-    for (const [id] of this.records) {
-      const enabled = this.enabledMap[id] ?? this.records.get(id)!.manifest.defaultEnabled;
-      if (!enabled) continue;
-      try {
-        await this.activate(id);
-      } catch (err) {
-        console.error(`[plugins] 插件 ${id} 启用失败，跳过`, err);
-      }
-    }
-    this.opts.runtime.registerIpc(IPC.PLUGINS_LIST, () => this.list());
-    this.opts.runtime.registerIpc(IPC.PLUGINS_SET_ENABLED, async (id: unknown, enabled: unknown) => {
-      if (typeof enabled !== "boolean") {
-        return { ok: false, error: "enabled 必须是布尔值" };
-      }
-      return this.setEnabled(String(id), enabled);
+        return this.open(id);
+      });
+      this.opts.runtime.registerIpc(IPC.PLUGINS_RESCAN, () => this.rescan());
+      await this.doRescan(false);
+      this.opts.onListChanged?.();
     });
-    this.opts.runtime.registerIpc(IPC.PLUGINS_OPEN, (id: unknown) => this.open(String(id)));
-    this.opts.onListChanged?.();
   }
 
-  async setEnabled(
+  rescan(): Promise<PluginOverview> {
+    return this.enqueueOperation(async () => {
+      await this.doRescan(true);
+      this.opts.onListChanged?.();
+      return this.overview();
+    });
+  }
+
+  setEnabled(
     id: string,
     enabled: boolean,
   ): Promise<{ ok: boolean; error?: string }> {
-    const record = this.records.get(id);
-    if (!record) return { ok: false, error: `插件不存在: ${id}` };
-    const running = this.instances.has(id);
-    if (running === enabled) return { ok: true };
-    try {
-      if (enabled) await this.activate(id);
-      else await this.deactivate(id);
+    return this.enqueueOperation(async () => {
+      const record = this.records.get(id);
+      if (!record) return { ok: false, error: `插件不存在: ${id}` };
+
       this.enabledMap[id] = enabled;
-      this.opts.saveEnabledMap({ ...this.enabledMap });
-      this.opts.onListChanged?.();
-      return { ok: true };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
-  }
-
-  async open(id: string): Promise<{ ok: boolean; error?: string }> {
-    const plugin = this.instances.get(id);
-    if (!plugin) return { ok: false, error: `插件未启用: ${id}` };
-    if (!plugin.open) return { ok: false, error: `插件不支持打开窗口: ${id}` };
-    try {
-      await plugin.open();
-      return { ok: true };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
-  }
-
-  async stop(): Promise<void> {
-    for (const id of Array.from(this.instances.keys())) {
       try {
+        this.opts.saveEnabledMap({ ...this.enabledMap });
+      } catch (error) {
+        return { ok: false, error: `保存插件开关失败: ${errorMessage(error)}` };
+      }
+
+      if (!enabled) {
         await this.deactivate(id);
-      } catch (err) {
-        console.warn(`[plugins] 插件 ${id} 停止失败，继续清理其他插件`, err);
+        this.statuses.set(id, "disabled");
+        this.errors.delete(id);
+        this.opts.onListChanged?.();
+        return { ok: true };
       }
-    }
-    for (const channel of [IPC.PLUGINS_LIST, IPC.PLUGINS_SET_ENABLED, IPC.PLUGINS_OPEN]) {
+
+      if (this.instances.has(id)) {
+        this.statuses.set(id, "running");
+        this.errors.delete(id);
+        return { ok: true };
+      }
       try {
-        this.opts.runtime.unregisterIpc(channel);
-      } catch (err) {
-        console.warn(`[plugins] 管理通道 ${channel} 清理失败`, err);
+        await this.activate(id);
+        this.opts.onListChanged?.();
+        return { ok: true };
+      } catch (error) {
+        const message = errorMessage(error);
+        this.statuses.set(id, "failed");
+        this.errors.set(id, message);
+        this.opts.onListChanged?.();
+        return { ok: false, error: message };
+      }
+    });
+  }
+
+  open(id: string): Promise<{ ok: boolean; error?: string }> {
+    return this.enqueueOperation(async () => {
+      const plugin = this.instances.get(id);
+      if (!plugin) return { ok: false, error: `插件未运行: ${id}` };
+      if (!plugin.open) return { ok: false, error: `插件不支持打开窗口: ${id}` };
+      try {
+        await plugin.open();
+        return { ok: true };
+      } catch (error) {
+        return { ok: false, error: errorMessage(error) };
+      }
+    });
+  }
+
+  stop(): Promise<void> {
+    return this.enqueueOperation(async () => {
+      if (!this.started) return;
+      for (const id of Array.from(this.instances.keys())) {
+        await this.deactivate(id);
+      }
+      for (const channel of [
+        IPC.PLUGINS_LIST,
+        IPC.PLUGINS_SET_ENABLED,
+        IPC.PLUGINS_OPEN,
+        IPC.PLUGINS_RESCAN,
+      ]) {
+        try {
+          this.opts.runtime.unregisterIpc(channel);
+        } catch (error) {
+          console.warn(`[plugins] 管理通道 ${channel} 清理失败`, error);
+        }
+      }
+      this.records.clear();
+      this.statuses.clear();
+      this.errors.clear();
+      this.scanIssues = [];
+      this.started = false;
+    });
+  }
+
+  private enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.operationTail.then(operation, operation);
+    this.operationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private isConfiguredEnabled(record: PluginRecord): boolean {
+    if (Object.prototype.hasOwnProperty.call(this.enabledMap, record.manifest.id)) {
+      return this.enabledMap[record.manifest.id] === true;
+    }
+    // User-installed code is never executed on first discovery without opt-in.
+    return record.source === "builtin" && record.manifest.defaultEnabled;
+  }
+
+  private scanAll(): {
+    records: Map<string, PluginRecord>;
+    issues: PluginScanIssue[];
+    failedRoots: Set<string>;
+  } {
+    const records = new Map<string, PluginRecord>();
+    const issues: PluginScanIssue[] = [];
+    const failedRoots = new Set<string>();
+    for (const root of this.opts.scanRoots) {
+      const onIssue = (issue: PluginScanIssue): void => {
+        issues.push(issue);
+        if (!issue.path) failedRoots.add(root.path);
+      };
+      for (const record of scanPluginDir(root.path, root.source, onIssue)) {
+        const existing = records.get(record.manifest.id);
+        if (existing) {
+          const issue: PluginScanIssue = {
+            root: root.path,
+            path: record.dir,
+            source: root.source,
+            message: `插件 id 重复，已保留 ${existing.dir}`,
+          };
+          issues.push(issue);
+          console.warn(`[plugins] ${issue.message}，忽略 ${record.dir}`);
+          continue;
+        }
+        records.set(record.manifest.id, record);
       }
     }
-    this.records.clear();
+    return { records, issues, failedRoots };
+  }
+
+  private async doRescan(reloadActive: boolean): Promise<void> {
+    const scanned = this.scanAll();
+    const previousRecords = this.records;
+    // A transient root-level read error must not unload already-running plugins.
+    for (const previous of previousRecords.values()) {
+      const failedRoot = this.opts.scanRoots.find(
+        (root) => scanned.failedRoots.has(root.path) && previous.source === root.source,
+      );
+      if (failedRoot && !scanned.records.has(previous.manifest.id)) {
+        scanned.records.set(previous.manifest.id, previous);
+      }
+    }
+    const activeBefore = new Set(this.instances.keys());
+
+    for (const id of activeBefore) {
+      const before = previousRecords.get(id);
+      const after = scanned.records.get(id);
+      const changed = !before
+        || !after
+        || before.dir !== after.dir
+        || before.fingerprint !== after.fingerprint;
+      if (reloadActive || changed) await this.deactivate(id);
+    }
+
+    this.records = scanned.records;
+    this.scanIssues = scanned.issues;
+
+    for (const id of Array.from(this.statuses.keys())) {
+      if (!this.records.has(id)) {
+        this.statuses.delete(id);
+        this.errors.delete(id);
+      }
+    }
+
+    for (const [id, record] of this.records) {
+      if (this.instances.has(id)) {
+        this.statuses.set(id, "running");
+        continue;
+      }
+      if (!this.isConfiguredEnabled(record)) {
+        this.statuses.set(id, "disabled");
+        this.errors.delete(id);
+        continue;
+      }
+      try {
+        await this.activate(id);
+      } catch (error) {
+        const message = errorMessage(error);
+        this.statuses.set(id, "failed");
+        this.errors.set(id, message);
+        console.error(`[plugins] 插件 ${id} 启用失败，跳过`, error);
+      }
+    }
   }
 
   private async activate(id: string): Promise<void> {
     const record = this.records.get(id);
     if (!record || this.instances.has(id)) return;
-    const plugin = await loadPlugin(record);
-    const ctx = createContext(
-      id,
-      path.join(this.opts.storageRoot, id),
-      this.opts.runtime,
-      record.manifest.deps,
-    );
+    this.statuses.set(id, "starting");
+    this.errors.delete(id);
     try {
-      await plugin.register(ctx);
-    } catch (err) {
-      // register 抛错时立即释放已注册资源，避免泄漏
-      await ctx.dispose();
-      throw err;
+      const plugin = await loadPlugin(record);
+      const ctx = createContext(
+        id,
+        path.join(this.opts.storageRoot, id),
+        this.opts.runtime,
+        record.manifest.deps,
+      );
+      try {
+        await plugin.register(ctx);
+      } catch (error) {
+        if (plugin.unregister) {
+          try {
+            await plugin.unregister();
+          } catch (cleanupError) {
+            console.warn(`[plugins] 插件 ${id} 激活回滚时 unregister 失败`, cleanupError);
+          }
+        }
+        await ctx.dispose();
+        throw error;
+      }
+      this.instances.set(id, plugin);
+      this.contexts.set(id, ctx);
+      this.statuses.set(id, "running");
+      console.log(`[plugins] 已启用 ${id}@${record.manifest.version}`);
+    } catch (error) {
+      const message = errorMessage(error);
+      this.statuses.set(id, "failed");
+      this.errors.set(id, message);
+      throw error;
     }
-    this.instances.set(id, plugin);
-    this.contexts.set(id, ctx);
-    console.log(`[plugins] 已启用 ${id}@${record.manifest.version}`);
   }
 
   private async deactivate(id: string): Promise<void> {
     const plugin = this.instances.get(id);
+    const context = this.contexts.get(id);
+    if (!plugin && !context) return;
+    this.statuses.set(id, "stopping");
     try {
       if (plugin?.unregister) {
         try {
           await plugin.unregister();
-        } catch (err) {
-          console.warn(`[plugins] 插件 ${id} unregister 失败，继续释放框架资源`, err);
+        } catch (error) {
+          console.warn(`[plugins] 插件 ${id} unregister 失败，继续释放框架资源`, error);
         }
       }
     } finally {
       try {
-        await this.contexts.get(id)?.dispose();
+        await context?.dispose();
       } finally {
         this.instances.delete(id);
         this.contexts.delete(id);
       }
     }
+    this.statuses.set(id, "disabled");
     console.log(`[plugins] 已禁用 ${id}`);
   }
 }

--- a/src/plugins/storage.test.ts
+++ b/src/plugins/storage.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPluginStorage } from "./storage";
+
+let tmp: string;
+
+afterEach(() => {
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = "";
+  }
+});
+
+describe("createPluginStorage", () => {
+  it("get/set 落盘并可读回；缺失返回 undefined", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-store-test-"));
+    const s = createPluginStorage(tmp);
+    s.set("cfg", { a: 1 });
+    expect(s.get<{ a: number }>("cfg")).toEqual({ a: 1 });
+    expect(s.get("missing")).toBeUndefined();
+    expect(s.rootDir()).toBe(tmp);
+  });
+
+  it("非法 key 抛错", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-store-test-"));
+    const s = createPluginStorage(tmp);
+    expect(() => s.set("../evil", 1)).toThrow(/非法存储 key/);
+    expect(() => s.get("a/b")).toThrow(/非法存储 key/);
+  });
+});

--- a/src/plugins/storage.ts
+++ b/src/plugins/storage.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { PluginStorage } from "./types";
+
+const KEY_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+
+/** 每个 key 一个 JSON 文件：<rootDir>/<key>.json */
+export function createPluginStorage(rootDir: string): PluginStorage {
+  mkdirSync(rootDir, { recursive: true });
+  const fileFor = (key: string): string => path.join(rootDir, `${key}.json`);
+  const assertKey = (key: string): void => {
+    if (!KEY_RE.test(key)) {
+      throw new Error(`非法存储 key: ${key}`);
+    }
+  };
+  return {
+    get<T>(key: string): T | undefined {
+      assertKey(key);
+      const p = fileFor(key);
+      if (!existsSync(p)) return undefined;
+      try {
+        return JSON.parse(readFileSync(p, "utf8")) as T;
+      } catch {
+        return undefined;
+      }
+    },
+    set<T>(key: string, value: T): void {
+      assertKey(key);
+      const p = fileFor(key);
+      // 原子写：先写临时文件再 rename，避免崩溃导致 JSON 损坏
+      const tmp = `${p}.tmp`;
+      writeFileSync(tmp, JSON.stringify(value, null, 2), "utf8");
+      renameSync(tmp, p);
+    },
+    rootDir: () => rootDir,
+  };
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,71 @@
+import type { ChannelAdapter } from "../main/channels/adapters/base";
+import type { ToolDefinition } from "../main/orchestrator/tool-registry";
+
+/** 插件清单：插件目录下必须存在 manifest.json */
+export interface PluginManifest {
+  /** 唯一 id，小写连字符，如 "my-plugin" */
+  id: string;
+  /** 显示名 */
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  /** 相对插件目录的入口文件，如 "index.cjs" / "index.mjs" / "index.js" */
+  entry: string;
+  defaultEnabled: boolean;
+  /** 需要注入的主程序内部依赖白名单 */
+  deps?: Array<"channels" | "llm">;
+}
+
+/** ChannelManager 的结构子集：运行时注入用，插件只允许使用这些方法 */
+export interface ChannelManagerLike {
+  has(id: string): boolean;
+  register(adapter: ChannelAdapter): void;
+  unregister(id: string): Promise<boolean>;
+  startOne(id: string): Promise<void>;
+}
+
+export interface PluginDeps {
+  channels?: { channelManager: ChannelManagerLike };
+  llm?: LlmDeps;
+}
+
+export interface LlmDeps {
+  /** 用主聊天模型完成一次非流式文本请求 */
+  generateText(
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+  ): Promise<string>;
+}
+
+export interface PluginStorage {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  rootDir(): string;
+}
+
+export interface PluginContext {
+  /** 插件 id（冗余，便于日志与调试） */
+  id: string;
+  registerTool(tool: ToolDefinition): void;
+  unregisterTool(toolId: string): void;
+  /** 自动加 plugin:<id>: 前缀 */
+  registerIpc(channel: string, handler: (...args: unknown[]) => unknown): void;
+  unregisterIpc(channel: string): void;
+  registerChannelAdapter(adapter: ChannelAdapter): Promise<void>;
+  unregisterChannelAdapter(channelId: string): Promise<void>;
+  storage: PluginStorage;
+  deps: PluginDeps;
+  log(...args: unknown[]): void;
+}
+
+export interface CyrenePlugin {
+  /** 可选的用户可见入口，例如打开插件工作台窗口 */
+  open?(): void | Promise<void>;
+  register(ctx: PluginContext): void | Promise<void>;
+  unregister?(): void | Promise<void>;
+}
+
+export interface PluginRecord {
+  manifest: PluginManifest;
+  dir: string;
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,71 +1,13 @@
-import type { ChannelAdapter } from "../main/channels/adapters/base";
-import type { ToolDefinition } from "../main/orchestrator/tool-registry";
+import type { PluginManifest } from "./api";
 
-/** 插件清单：插件目录下必须存在 manifest.json */
-export interface PluginManifest {
-  /** 唯一 id，小写连字符，如 "my-plugin" */
-  id: string;
-  /** 显示名 */
-  name: string;
-  version: string;
-  description: string;
-  author: string;
-  /** 相对插件目录的入口文件，如 "index.cjs" / "index.mjs" / "index.js" */
-  entry: string;
-  defaultEnabled: boolean;
-  /** 需要注入的主程序内部依赖白名单 */
-  deps?: Array<"channels" | "llm">;
-}
+export * from "./api";
 
-/** ChannelManager 的结构子集：运行时注入用，插件只允许使用这些方法 */
-export interface ChannelManagerLike {
-  has(id: string): boolean;
-  register(adapter: ChannelAdapter): void;
-  unregister(id: string): Promise<boolean>;
-  startOne(id: string): Promise<void>;
-}
-
-export interface PluginDeps {
-  channels?: { channelManager: ChannelManagerLike };
-  llm?: LlmDeps;
-}
-
-export interface LlmDeps {
-  /** 用主聊天模型完成一次非流式文本请求 */
-  generateText(
-    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
-  ): Promise<string>;
-}
-
-export interface PluginStorage {
-  get<T>(key: string): T | undefined;
-  set<T>(key: string, value: T): void;
-  rootDir(): string;
-}
-
-export interface PluginContext {
-  /** 插件 id（冗余，便于日志与调试） */
-  id: string;
-  registerTool(tool: ToolDefinition): void;
-  unregisterTool(toolId: string): void;
-  /** 自动加 plugin:<id>: 前缀 */
-  registerIpc(channel: string, handler: (...args: unknown[]) => unknown): void;
-  unregisterIpc(channel: string): void;
-  registerChannelAdapter(adapter: ChannelAdapter): Promise<void>;
-  unregisterChannelAdapter(channelId: string): Promise<void>;
-  storage: PluginStorage;
-  deps: PluginDeps;
-  log(...args: unknown[]): void;
-}
-
-export interface CyrenePlugin {
-  /** 可选的用户可见入口，例如打开插件工作台窗口 */
-  open?(): void | Promise<void>;
-  register(ctx: PluginContext): void | Promise<void>;
-  unregister?(): void | Promise<void>;
-}
+export type PluginSource = "builtin" | "user";
 
 export interface PluginRecord {
   manifest: PluginManifest;
   dir: string;
+  source: PluginSource;
+  /** Manifest + entry stat fingerprint used by rescan/reload. */
+  fingerprint: string;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -445,6 +445,7 @@ const pluginsApi = {
     ipcRenderer.invoke(IPC.PLUGINS_SET_ENABLED, id, enabled),
   open: (id: string) => ipcRenderer.invoke(IPC.PLUGINS_OPEN, id),
   rescan: () => ipcRenderer.invoke(IPC.PLUGINS_RESCAN),
+  uninstall: (id: string) => ipcRenderer.invoke(IPC.PLUGINS_UNINSTALL, id),
 };
 
 contextBridge.exposeInMainWorld("plugins", pluginsApi);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -439,6 +439,15 @@ const settingsApi = {
 
 contextBridge.exposeInMainWorld("settings", settingsApi);
 
+const pluginsApi = {
+  list: () => ipcRenderer.invoke(IPC.PLUGINS_LIST),
+  setEnabled: (id: string, enabled: boolean) =>
+    ipcRenderer.invoke(IPC.PLUGINS_SET_ENABLED, id, enabled),
+  open: (id: string) => ipcRenderer.invoke(IPC.PLUGINS_OPEN, id),
+};
+
+contextBridge.exposeInMainWorld("plugins", pluginsApi);
+
 const schedulerApi = {
   list: () => ipcRenderer.invoke(IPC.SCHEDULER_LIST),
   add: (input: unknown) => ipcRenderer.invoke(IPC.SCHEDULER_ADD, input),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -444,6 +444,7 @@ const pluginsApi = {
   setEnabled: (id: string, enabled: boolean) =>
     ipcRenderer.invoke(IPC.PLUGINS_SET_ENABLED, id, enabled),
   open: (id: string) => ipcRenderer.invoke(IPC.PLUGINS_OPEN, id),
+  rescan: () => ipcRenderer.invoke(IPC.PLUGINS_RESCAN),
 };
 
 contextBridge.exposeInMainWorld("plugins", pluginsApi);

--- a/src/renderer/settings/feature-plugins/dom.ts
+++ b/src/renderer/settings/feature-plugins/dom.ts
@@ -1,0 +1,2 @@
+export const featurePluginsPanel = document.getElementById("feature-plugins-panel") as HTMLElement | null;
+export const featurePluginsList = document.getElementById("feature-plugins-list") as HTMLElement | null;

--- a/src/renderer/settings/feature-plugins/dom.ts
+++ b/src/renderer/settings/feature-plugins/dom.ts
@@ -1,2 +1,3 @@
 export const featurePluginsPanel = document.getElementById("feature-plugins-panel") as HTMLElement | null;
 export const featurePluginsList = document.getElementById("feature-plugins-list") as HTMLElement | null;
+export const featurePluginsRescan = document.getElementById("feature-plugins-rescan") as HTMLButtonElement | null;

--- a/src/renderer/settings/feature-plugins/panel.test.ts
+++ b/src/renderer/settings/feature-plugins/panel.test.ts
@@ -1,39 +1,94 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+function runningPlugin() {
+  return {
+    id: "example",
+    name: "Example",
+    version: "0.1.0",
+    description: "example plugin",
+    author: "Cyrene",
+    entry: "index.cjs",
+    apiVersion: 1,
+    source: "user" as const,
+    path: "C:\\plugins\\example",
+    defaultEnabled: true,
+    configuredEnabled: true,
+    enabled: true,
+    status: "running" as const,
+    hasUnregister: true,
+    canOpen: true,
+  };
+}
+
 describe("feature plugin settings panel", () => {
   beforeEach(() => {
-    document.body.innerHTML = '<div id="feature-plugins-list"></div>';
+    document.body.innerHTML = [
+      '<button id="feature-plugins-rescan"></button>',
+      '<div id="feature-plugins-list"></div>',
+    ].join("");
     vi.resetModules();
   });
 
-  it("renders an enabled plugin and opens its controlled window", async () => {
+  it("renders runtime state/source and opens a running plugin", async () => {
     const open = vi.fn(async () => ({ ok: true }));
     const api = {
-      list: async () => [{
-        id: "example",
-        name: "Example",
-        version: "0.1.0",
-        description: "example plugin",
-        author: "Cyrene",
-        entry: "index.cjs",
-        defaultEnabled: true,
-        enabled: true,
-        hasUnregister: true,
-        canOpen: true,
-      }],
+      list: async () => ({ plugins: [runningPlugin()], issues: [] }),
       setEnabled: vi.fn(async () => ({ ok: true })),
       open,
+      rescan: vi.fn(async () => ({ plugins: [runningPlugin()], issues: [] })),
     };
     const { renderFeaturePlugins } = await import("./panel");
 
     await renderFeaturePlugins(api);
     const buttons = Array.from(document.querySelectorAll("button"));
-    expect(document.body.textContent).toContain("Example v0.1.0");
+    expect(document.body.textContent).toContain("Example v0.1.0 · 运行中");
+    expect(document.body.textContent).toContain("用户插件 · API v1");
     expect(buttons.map((button) => button.textContent)).toContain("打开");
 
     buttons.find((button) => button.textContent === "打开")!.click();
     await vi.waitFor(() => expect(open).toHaveBeenCalledWith("example"));
+  });
+
+  it("shows persistent activation and scan errors", async () => {
+    const api = {
+      list: async () => ({
+        plugins: [{
+          ...runningPlugin(),
+          enabled: false,
+          status: "failed" as const,
+          error: "register exploded",
+        }],
+        issues: [{
+          root: "C:\\plugins",
+          path: "C:\\plugins\\broken",
+          source: "user" as const,
+          message: "version 必须是合法 SemVer",
+        }],
+      }),
+      setEnabled: vi.fn(async () => ({ ok: false, error: "still broken" })),
+      open: vi.fn(async () => ({ ok: true })),
+      rescan: vi.fn(async () => ({ plugins: [], issues: [] })),
+    };
+    const { renderFeaturePlugins } = await import("./panel");
+    await renderFeaturePlugins(api);
+    expect(document.body.textContent).toContain("错误：register exploded");
+    expect(document.body.textContent).toContain("version 必须是合法 SemVer");
+    expect(document.body.textContent).toContain("重试");
+    expect(document.body.textContent).toContain("停用");
+  });
+
+  it("rescan button refreshes plugins without restarting", async () => {
+    const api = {
+      list: vi.fn(async () => ({ plugins: [runningPlugin()], issues: [] })),
+      setEnabled: vi.fn(async () => ({ ok: true })),
+      open: vi.fn(async () => ({ ok: true })),
+      rescan: vi.fn(async () => ({ plugins: [runningPlugin()], issues: [] })),
+    };
+    const { renderFeaturePlugins } = await import("./panel");
+    await renderFeaturePlugins(api);
+    document.querySelector<HTMLButtonElement>("#feature-plugins-rescan")!.click();
+    await vi.waitFor(() => expect(api.rescan).toHaveBeenCalledTimes(1));
   });
 
   it("renders a useful error when the plugin list cannot be loaded", async () => {
@@ -41,11 +96,11 @@ describe("feature plugin settings panel", () => {
       list: async () => { throw new Error("IPC unavailable"); },
       setEnabled: vi.fn(async () => ({ ok: true })),
       open: vi.fn(async () => ({ ok: true })),
+      rescan: vi.fn(async () => ({ plugins: [], issues: [] })),
     };
     const { renderFeaturePlugins } = await import("./panel");
 
     await renderFeaturePlugins(api);
-
     expect(document.body.textContent).toContain("插件列表加载失败：IPC unavailable");
   });
 });

--- a/src/renderer/settings/feature-plugins/panel.test.ts
+++ b/src/renderer/settings/feature-plugins/panel.test.ts
@@ -37,6 +37,7 @@ describe("feature plugin settings panel", () => {
       setEnabled: vi.fn(async () => ({ ok: true })),
       open,
       rescan: vi.fn(async () => ({ plugins: [runningPlugin()], issues: [] })),
+      uninstall: vi.fn(async () => ({ ok: true })),
     };
     const { renderFeaturePlugins } = await import("./panel");
 
@@ -69,6 +70,7 @@ describe("feature plugin settings panel", () => {
       setEnabled: vi.fn(async () => ({ ok: false, error: "still broken" })),
       open: vi.fn(async () => ({ ok: true })),
       rescan: vi.fn(async () => ({ plugins: [], issues: [] })),
+      uninstall: vi.fn(async () => ({ ok: true })),
     };
     const { renderFeaturePlugins } = await import("./panel");
     await renderFeaturePlugins(api);
@@ -84,6 +86,7 @@ describe("feature plugin settings panel", () => {
       setEnabled: vi.fn(async () => ({ ok: true })),
       open: vi.fn(async () => ({ ok: true })),
       rescan: vi.fn(async () => ({ plugins: [runningPlugin()], issues: [] })),
+      uninstall: vi.fn(async () => ({ ok: true })),
     };
     const { renderFeaturePlugins } = await import("./panel");
     await renderFeaturePlugins(api);
@@ -97,10 +100,37 @@ describe("feature plugin settings panel", () => {
       setEnabled: vi.fn(async () => ({ ok: true })),
       open: vi.fn(async () => ({ ok: true })),
       rescan: vi.fn(async () => ({ plugins: [], issues: [] })),
+      uninstall: vi.fn(async () => ({ ok: true })),
     };
     const { renderFeaturePlugins } = await import("./panel");
 
     await renderFeaturePlugins(api);
     expect(document.body.textContent).toContain("插件列表加载失败：IPC unavailable");
+  });
+
+  it("asks for confirmation and uninstalls only user plugins", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const uninstall = vi.fn(async () => ({ ok: true }));
+    const builtin = { ...runningPlugin(), id: "builtin", name: "Builtin", source: "builtin" as const };
+    const api = {
+      list: vi.fn()
+        .mockResolvedValueOnce({ plugins: [runningPlugin(), builtin], issues: [] })
+        .mockResolvedValueOnce({ plugins: [builtin], issues: [] }),
+      setEnabled: vi.fn(async () => ({ ok: true })),
+      open: vi.fn(async () => ({ ok: true })),
+      rescan: vi.fn(async () => ({ plugins: [], issues: [] })),
+      uninstall,
+    };
+    const { renderFeaturePlugins } = await import("./panel");
+    await renderFeaturePlugins(api);
+
+    const uninstallButtons = Array.from(document.querySelectorAll("button"))
+      .filter((button) => button.textContent === "卸载");
+    expect(uninstallButtons).toHaveLength(1);
+    uninstallButtons[0].click();
+
+    await vi.waitFor(() => expect(uninstall).toHaveBeenCalledWith("example"));
+    expect(window.confirm).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(document.body.textContent).not.toContain("Example v0.1.0"));
   });
 });

--- a/src/renderer/settings/feature-plugins/panel.test.ts
+++ b/src/renderer/settings/feature-plugins/panel.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("feature plugin settings panel", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="feature-plugins-list"></div>';
+    vi.resetModules();
+  });
+
+  it("renders an enabled plugin and opens its controlled window", async () => {
+    const open = vi.fn(async () => ({ ok: true }));
+    const api = {
+      list: async () => [{
+        id: "example",
+        name: "Example",
+        version: "0.1.0",
+        description: "example plugin",
+        author: "Cyrene",
+        entry: "index.cjs",
+        defaultEnabled: true,
+        enabled: true,
+        hasUnregister: true,
+        canOpen: true,
+      }],
+      setEnabled: vi.fn(async () => ({ ok: true })),
+      open,
+    };
+    const { renderFeaturePlugins } = await import("./panel");
+
+    await renderFeaturePlugins(api);
+    const buttons = Array.from(document.querySelectorAll("button"));
+    expect(document.body.textContent).toContain("Example v0.1.0");
+    expect(buttons.map((button) => button.textContent)).toContain("打开");
+
+    buttons.find((button) => button.textContent === "打开")!.click();
+    await vi.waitFor(() => expect(open).toHaveBeenCalledWith("example"));
+  });
+
+  it("renders a useful error when the plugin list cannot be loaded", async () => {
+    const api = {
+      list: async () => { throw new Error("IPC unavailable"); },
+      setEnabled: vi.fn(async () => ({ ok: true })),
+      open: vi.fn(async () => ({ ok: true })),
+    };
+    const { renderFeaturePlugins } = await import("./panel");
+
+    await renderFeaturePlugins(api);
+
+    expect(document.body.textContent).toContain("插件列表加载失败：IPC unavailable");
+  });
+});

--- a/src/renderer/settings/feature-plugins/panel.ts
+++ b/src/renderer/settings/feature-plugins/panel.ts
@@ -1,4 +1,11 @@
-import { featurePluginsList } from "./dom";
+import { featurePluginsList, featurePluginsRescan } from "./dom";
+
+export type FeaturePluginRuntimeStatus =
+  | "disabled"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "failed";
 
 export interface FeaturePluginListEntry {
   id: string;
@@ -7,16 +14,35 @@ export interface FeaturePluginListEntry {
   description: string;
   author: string;
   entry: string;
+  apiVersion: number;
+  source: "builtin" | "user";
+  path: string;
   defaultEnabled: boolean;
+  configuredEnabled: boolean;
   enabled: boolean;
+  status: FeaturePluginRuntimeStatus;
+  error?: string;
   hasUnregister: boolean;
   canOpen: boolean;
 }
 
+export interface FeaturePluginScanIssue {
+  root: string;
+  path?: string;
+  source: "builtin" | "user";
+  message: string;
+}
+
+export interface FeaturePluginOverview {
+  plugins: FeaturePluginListEntry[];
+  issues: FeaturePluginScanIssue[];
+}
+
 export interface FeaturePluginsApi {
-  list(): Promise<FeaturePluginListEntry[]>;
+  list(): Promise<FeaturePluginOverview | FeaturePluginListEntry[]>;
   setEnabled(id: string, enabled: boolean): Promise<{ ok: boolean; error?: string }>;
   open(id: string): Promise<{ ok: boolean; error?: string }>;
+  rescan(): Promise<FeaturePluginOverview>;
 }
 
 declare global {
@@ -31,17 +57,74 @@ function appendTransientError(row: HTMLElement, message: string): void {
   error.style.color = "#e5484d";
   error.style.fontSize = "12px";
   row.appendChild(error);
-  setTimeout(() => error.remove(), 4000);
+  setTimeout(() => error.remove(), 6000);
+}
+
+function normalizeOverview(
+  value: FeaturePluginOverview | FeaturePluginListEntry[],
+): FeaturePluginOverview {
+  return Array.isArray(value) ? { plugins: value, issues: [] } : value;
+}
+
+function statusText(item: FeaturePluginListEntry): string {
+  switch (item.status) {
+    case "running": return "运行中";
+    case "starting": return "启动中";
+    case "stopping": return "停止中";
+    case "failed": return "启动失败";
+    default: return "已停用";
+  }
+}
+
+function renderIssues(list: HTMLElement, issues: FeaturePluginScanIssue[]): void {
+  if (issues.length === 0) return;
+  const box = document.createElement("div");
+  box.className = "settings-empty";
+  const heading = document.createElement("strong");
+  heading.textContent = `发现 ${issues.length} 个插件扫描问题`;
+  box.appendChild(heading);
+  for (const issue of issues) {
+    const line = document.createElement("div");
+    line.textContent = `${issue.path ?? issue.root}：${issue.message}`;
+    line.style.color = "#e5484d";
+    line.style.fontSize = "12px";
+    box.appendChild(line);
+  }
+  list.appendChild(box);
+}
+
+function bindRescan(
+  api: FeaturePluginsApi,
+  list: HTMLElement,
+  button: HTMLButtonElement | null,
+): void {
+  if (!button || button.dataset.bound === "true") return;
+  button.dataset.bound = "true";
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    button.textContent = "刷新中…";
+    try {
+      await api.rescan();
+      await renderFeaturePlugins(api, list, button);
+    } catch (error) {
+      appendTransientError(list, `刷新失败：${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      button.disabled = false;
+      button.textContent = "刷新插件";
+    }
+  });
 }
 
 export async function renderFeaturePlugins(
   api: FeaturePluginsApi | undefined = window.plugins,
   list: HTMLElement | null = featurePluginsList,
+  rescanButton: HTMLButtonElement | null = featurePluginsRescan,
 ): Promise<void> {
   if (!list || !api) return;
-  let items: FeaturePluginListEntry[];
+  bindRescan(api, list, rescanButton);
+  let overview: FeaturePluginOverview;
   try {
-    items = await api.list();
+    overview = normalizeOverview(await api.list());
   } catch (error) {
     list.replaceChildren();
     const failure = document.createElement("div");
@@ -51,29 +134,41 @@ export async function renderFeaturePlugins(
     return;
   }
   list.replaceChildren();
-  if (items.length === 0) {
+  renderIssues(list, overview.issues);
+  if (overview.plugins.length === 0) {
     const empty = document.createElement("div");
     empty.className = "settings-empty";
-    empty.textContent = "暂无插件：把插件目录放进 userData/plugins/ 后重启生效";
+    empty.textContent = "暂无插件：把插件目录放进 userData/plugins/ 后点击“刷新插件”";
     list.appendChild(empty);
     return;
   }
 
-  for (const item of items) {
+  for (const item of overview.plugins) {
     const row = document.createElement("div");
     row.className = "setting-row";
     const info = document.createElement("div");
     const name = document.createElement("strong");
-    name.textContent = `${item.name} v${item.version}`;
+    name.textContent = `${item.name} v${item.version} · ${statusText(item)}`;
     const description = document.createElement("span");
     description.textContent = `${item.description}（${item.author}）`;
-    info.append(name, description);
+    const source = document.createElement("span");
+    source.textContent = `${item.source === "builtin" ? "内置插件" : "用户插件"} · API v${item.apiVersion} · ${item.path}`;
+    source.style.fontSize = "12px";
+    source.style.opacity = "0.72";
+    info.append(name, description, source);
+    if (item.error) {
+      const persistentError = document.createElement("span");
+      persistentError.textContent = `错误：${item.error}`;
+      persistentError.style.color = "#e5484d";
+      persistentError.style.fontSize = "12px";
+      info.appendChild(persistentError);
+    }
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
     actions.style.gap = "8px";
 
-    if (item.enabled && item.canOpen) {
+    if (item.status === "running" && item.canOpen) {
       const open = document.createElement("button");
       open.type = "button";
       open.className = "save-btn save-btn--ghost";
@@ -92,19 +187,40 @@ export async function renderFeaturePlugins(
       actions.appendChild(open);
     }
 
+    if (item.status === "failed") {
+      const retry = document.createElement("button");
+      retry.type = "button";
+      retry.className = "save-btn save-btn--ghost";
+      retry.textContent = "重试";
+      retry.addEventListener("click", async () => {
+        retry.disabled = true;
+        try {
+          const result = await api.setEnabled(item.id, true);
+          if (!result.ok) appendTransientError(row, `重试失败：${result.error ?? "未知错误"}`);
+          await renderFeaturePlugins(api, list, rescanButton);
+        } catch (error) {
+          appendTransientError(row, `重试失败：${error instanceof Error ? error.message : String(error)}`);
+        } finally {
+          retry.disabled = false;
+        }
+      });
+      actions.appendChild(retry);
+    }
+
     const toggle = document.createElement("button");
     toggle.type = "button";
-    toggle.className = item.enabled ? "save-btn" : "save-btn save-btn--ghost";
-    toggle.textContent = item.enabled ? "已启用" : "已停用";
+    toggle.className = item.configuredEnabled ? "save-btn" : "save-btn save-btn--ghost";
+    toggle.textContent = item.configuredEnabled ? "停用" : "启用";
+    toggle.disabled = item.status === "starting" || item.status === "stopping";
     toggle.addEventListener("click", async () => {
       toggle.disabled = true;
+      const targetEnabled = !item.configuredEnabled;
       try {
-        const result = await api.setEnabled(item.id, !item.enabled);
+        const result = await api.setEnabled(item.id, targetEnabled);
         if (!result.ok) {
           appendTransientError(row, `切换失败：${result.error ?? "未知错误"}`);
-          return;
         }
-        await renderFeaturePlugins(api, list);
+        await renderFeaturePlugins(api, list, rescanButton);
       } catch (error) {
         appendTransientError(row, `切换失败：${error instanceof Error ? error.message : String(error)}`);
       } finally {

--- a/src/renderer/settings/feature-plugins/panel.ts
+++ b/src/renderer/settings/feature-plugins/panel.ts
@@ -1,0 +1,118 @@
+import { featurePluginsList } from "./dom";
+
+export interface FeaturePluginListEntry {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  entry: string;
+  defaultEnabled: boolean;
+  enabled: boolean;
+  hasUnregister: boolean;
+  canOpen: boolean;
+}
+
+export interface FeaturePluginsApi {
+  list(): Promise<FeaturePluginListEntry[]>;
+  setEnabled(id: string, enabled: boolean): Promise<{ ok: boolean; error?: string }>;
+  open(id: string): Promise<{ ok: boolean; error?: string }>;
+}
+
+declare global {
+  interface Window {
+    plugins?: FeaturePluginsApi;
+  }
+}
+
+function appendTransientError(row: HTMLElement, message: string): void {
+  const error = document.createElement("span");
+  error.textContent = message;
+  error.style.color = "#e5484d";
+  error.style.fontSize = "12px";
+  row.appendChild(error);
+  setTimeout(() => error.remove(), 4000);
+}
+
+export async function renderFeaturePlugins(
+  api: FeaturePluginsApi | undefined = window.plugins,
+  list: HTMLElement | null = featurePluginsList,
+): Promise<void> {
+  if (!list || !api) return;
+  let items: FeaturePluginListEntry[];
+  try {
+    items = await api.list();
+  } catch (error) {
+    list.replaceChildren();
+    const failure = document.createElement("div");
+    failure.className = "settings-empty";
+    failure.textContent = `插件列表加载失败：${error instanceof Error ? error.message : String(error)}`;
+    list.appendChild(failure);
+    return;
+  }
+  list.replaceChildren();
+  if (items.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "settings-empty";
+    empty.textContent = "暂无插件：把插件目录放进 userData/plugins/ 后重启生效";
+    list.appendChild(empty);
+    return;
+  }
+
+  for (const item of items) {
+    const row = document.createElement("div");
+    row.className = "setting-row";
+    const info = document.createElement("div");
+    const name = document.createElement("strong");
+    name.textContent = `${item.name} v${item.version}`;
+    const description = document.createElement("span");
+    description.textContent = `${item.description}（${item.author}）`;
+    info.append(name, description);
+
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.gap = "8px";
+
+    if (item.enabled && item.canOpen) {
+      const open = document.createElement("button");
+      open.type = "button";
+      open.className = "save-btn save-btn--ghost";
+      open.textContent = "打开";
+      open.addEventListener("click", async () => {
+        open.disabled = true;
+        try {
+          const result = await api.open(item.id);
+          if (!result.ok) appendTransientError(row, `打开失败：${result.error ?? "未知错误"}`);
+        } catch (error) {
+          appendTransientError(row, `打开失败：${error instanceof Error ? error.message : String(error)}`);
+        } finally {
+          open.disabled = false;
+        }
+      });
+      actions.appendChild(open);
+    }
+
+    const toggle = document.createElement("button");
+    toggle.type = "button";
+    toggle.className = item.enabled ? "save-btn" : "save-btn save-btn--ghost";
+    toggle.textContent = item.enabled ? "已启用" : "已停用";
+    toggle.addEventListener("click", async () => {
+      toggle.disabled = true;
+      try {
+        const result = await api.setEnabled(item.id, !item.enabled);
+        if (!result.ok) {
+          appendTransientError(row, `切换失败：${result.error ?? "未知错误"}`);
+          return;
+        }
+        await renderFeaturePlugins(api, list);
+      } catch (error) {
+        appendTransientError(row, `切换失败：${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        toggle.disabled = false;
+      }
+    });
+    actions.appendChild(toggle);
+    row.append(info, actions);
+    list.appendChild(row);
+  }
+}

--- a/src/renderer/settings/feature-plugins/panel.ts
+++ b/src/renderer/settings/feature-plugins/panel.ts
@@ -43,6 +43,7 @@ export interface FeaturePluginsApi {
   setEnabled(id: string, enabled: boolean): Promise<{ ok: boolean; error?: string }>;
   open(id: string): Promise<{ ok: boolean; error?: string }>;
   rescan(): Promise<FeaturePluginOverview>;
+  uninstall(id: string): Promise<{ ok: boolean; error?: string; overview?: FeaturePluginOverview }>;
 }
 
 declare global {
@@ -228,6 +229,34 @@ export async function renderFeaturePlugins(
       }
     });
     actions.appendChild(toggle);
+
+    if (item.source === "user") {
+      const uninstall = document.createElement("button");
+      uninstall.type = "button";
+      uninstall.className = "save-btn save-btn--ghost";
+      uninstall.textContent = "卸载";
+      uninstall.disabled = item.status === "starting" || item.status === "stopping";
+      uninstall.addEventListener("click", async () => {
+        const confirmed = window.confirm(
+          `确定卸载用户插件“${item.name}”吗？\n\n将删除插件程序目录，但保留 userData/plugin-data 中的插件数据。`,
+        );
+        if (!confirmed) return;
+        uninstall.disabled = true;
+        try {
+          const result = await api.uninstall(item.id);
+          if (!result.ok) {
+            appendTransientError(row, `卸载失败：${result.error ?? "未知错误"}`);
+            return;
+          }
+          await renderFeaturePlugins(api, list, rescanButton);
+        } catch (error) {
+          appendTransientError(row, `卸载失败：${error instanceof Error ? error.message : String(error)}`);
+        } finally {
+          uninstall.disabled = false;
+        }
+      });
+      actions.appendChild(uninstall);
+    }
     row.append(info, actions);
     list.appendChild(row);
   }

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -23,6 +23,7 @@
         <hr class="nav-divider" />
         <button type="button" class="nav-item" data-section="tasks"><span><svg width="18" height="18" viewBox="0 0 48 48" fill="none" aria-hidden="true"><path d="M23.9998 44.3332C34.1251 44.3332 42.3332 36.1251 42.3332 25.9999C42.3332 15.8747 34.1251 7.66656 23.9998 7.66656C13.8746 7.66656 5.6665 15.8747 5.6665 25.9999C5.6665 36.1251 13.8746 44.3332 23.9998 44.3332Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M23.7594 15.3536L23.7582 26.3624L31.5305 34.1347" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M4 9.00001L11 4.00001" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M44 9.00001L37 4.00001" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/></svg></span>定时任务</button>
         <button type="button" class="nav-item" data-section="plugins"><span><svg class="nav-item__icon" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd" aria-hidden="true"><title>工具配置</title><path d="M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z"/><path d="M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z"/></svg></span>工具配置</button>
+        <button type="button" class="nav-item" data-section="feature-plugins"><span><svg class="nav-item__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></span>功能插件</button>
         <hr class="nav-divider" />
         <button type="button" class="nav-item" data-section="preferences"><span><svg class="nav-item__icon" width="18" height="18" viewBox="0 0 48 48" fill="none" aria-hidden="true"><title>偏好设置</title><path d="M12 35.0137H9H4V8.01273C4 6.90868 4.89543 6.01367 6 6.01367H42C43.1046 6.01367 44 6.90868 44 8.01273V35.0137H36" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M24 32L14 42H34L24 32Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg></span>偏好设置</button>
         <button type="button" class="nav-item" data-section="appearance"><span><svg class="nav-item__icon" width="18" height="18" viewBox="0 0 48 48" fill="none" aria-hidden="true"><title>外观设置</title><path d="M24 44C29.9601 44 26.3359 35.136 30 31C33.1264 27.4709 44 29.0856 44 24C44 12.9543 35.0457 4 24 4C12.9543 4 4 12.9543 4 24C4 35.0457 12.9543 44 24 44Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M28 17C29.6569 17 31 15.6569 31 14C31 12.3431 29.6569 11 28 11C26.3431 11 25 12.3431 25 14C25 15.6569 26.3431 17 28 17Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M16 21C17.6569 21 19 19.6569 19 18C19 16.3431 17.6569 15 16 15C14.3431 15 13 16.3431 13 18C13 19.6569 14.3431 21 16 21Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M17 34C18.6569 34 20 32.6569 20 31C20 29.3431 18.6569 28 17 28C15.3431 28 14 29.3431 14 31C14 32.6569 15.3431 34 17 34Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg></span>外观设置</button>
@@ -1456,6 +1457,16 @@
               </div>
             </article>
           </div>
+        </section>
+
+        <section class="settings-panel is-hidden" id="feature-plugins-panel" data-panel="feature-plugins">
+          <div class="plugin-panel-heading">
+            <div>
+              <h1 class="plugin-panel-heading__title">功能插件</h1>
+              <p>插件以“目录 + manifest.json + 入口文件”放在 userData/plugins/ 下，重启应用后即可在这里启停。</p>
+            </div>
+          </div>
+          <div id="feature-plugins-list" class="settings-list"></div>
         </section>
 
         <section class="settings-panel is-hidden" id="music-panel" data-panel="music">

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -1463,8 +1463,9 @@
           <div class="plugin-panel-heading">
             <div>
               <h1 class="plugin-panel-heading__title">功能插件</h1>
-              <p>插件以“目录 + manifest.json + 入口文件”放在 userData/plugins/ 下，重启应用后即可在这里启停。</p>
+              <p>用户插件首次发现时保持停用。确认来源可信后再手动启用；刷新可发现新增、删除和更新。</p>
             </div>
+            <button type="button" class="save-btn save-btn--ghost" id="feature-plugins-rescan">刷新插件</button>
           </div>
           <div id="feature-plugins-list" class="settings-list"></div>
         </section>

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -1463,7 +1463,7 @@
           <div class="plugin-panel-heading">
             <div>
               <h1 class="plugin-panel-heading__title">功能插件</h1>
-              <p>用户插件首次发现时保持停用。确认来源可信后再手动启用；刷新可发现新增、删除和更新。</p>
+              <p>用户插件首次发现时保持停用。确认来源可信后再手动启用；刷新可发现新增和更新。卸载只删除插件程序，默认保留插件数据。</p>
             </div>
             <button type="button" class="save-btn save-btn--ghost" id="feature-plugins-rescan">刷新插件</button>
           </div>

--- a/src/renderer/settings/settings.ts
+++ b/src/renderer/settings/settings.ts
@@ -111,6 +111,8 @@ import {
   deleteSchedulerTask, toggleSchedulerHistory,
 } from "./scheduler/panel";
 import { loadMusicPanel, disposeMusicPanel } from "./music/panel";
+import { featurePluginsPanel } from "./feature-plugins/dom";
+import { renderFeaturePlugins } from "./feature-plugins/panel";
 import { loadChannelsPanel } from "./channels/panel";
 import { renderProactiveDeliveryAvailability } from "./channels/panel";
 import "./asr/panel";  // 副作用导入：执行事件绑定 + 初始加载
@@ -304,6 +306,7 @@ const NAV_LABELS: Record<string, { emoji: string; title: string; hint: string }>
   user: { emoji: `<svg style="vertical-align:-3px" width="24" height="24" viewBox="0 0 48 48" fill="none" aria-hidden="true"><path d="M44 8H4V38H19L24 43L29 38H44V8Z" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="24" cy="19" r="5" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M33 32C33 27.5817 28.9706 24 24 24C19.0294 24 15 27.5817 15 32" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/></svg>`, title: "用户信息", hint: "编辑你的个人资料" },
   tasks: { emoji: `<svg style="vertical-align:-3px" width="24" height="24" viewBox="0 0 48 48" fill="none" aria-hidden="true"><path d="M23.9998 44.3332C34.1251 44.3332 42.3332 36.1251 42.3332 25.9999C42.3332 15.8747 34.1251 7.66656 23.9998 7.66656C13.8746 7.66656 5.6665 15.8747 5.6665 25.9999C5.6665 36.1251 13.8746 44.3332 23.9998 44.3332Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M23.7594 15.3536L23.7582 26.3624L31.5305 34.1347" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M4 9.00001L11 4.00001" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M44 9.00001L37 4.00001" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/></svg>`, title: "定时任务", hint: "管理定时提醒与日程" },
   plugins: { emoji: "🔌", title: "工具配置", hint: "管理昔涟可调用的工具能力" },
+  "feature-plugins": { emoji: "🧩", title: "功能插件", hint: "启停和打开独立功能插件" },
   preferences: { emoji: `<svg width="24" height="24" viewBox="0 0 48 48" fill="none" aria-hidden="true" style="vertical-align:-3px"><title>偏好设置</title><path d="M12 35.0137H9H4V8.01273C4 6.90868 4.89543 6.01367 6 6.01367H42C43.1046 6.01367 44 6.90868 44 8.01273V35.0137H36" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/><path d="M24 32L14 42H34L24 32Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg>`, title: "偏好设置", hint: "设置聊天窗口和输出行为的默认偏好" },
   appearance: { emoji: `<svg width="24" height="24" viewBox="0 0 48 48" fill="none" aria-hidden="true" style="vertical-align:-3px"><title>外观设置</title><path d="M24 44C29.9601 44 26.3359 35.136 30 31C33.1264 27.4709 44 29.0856 44 24C44 12.9543 35.0457 4 24 4C12.9543 4 4 12.9543 4 24C4 35.0457 12.9543 44 24 44Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M28 17C29.6569 17 31 15.6569 31 14C31 12.3431 29.6569 11 28 11C26.3431 11 25 12.3431 25 14C25 15.6569 26.3431 17 28 17Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M16 21C17.6569 21 19 19.6569 19 18C19 16.3431 17.6569 15 16 15C14.3431 15 13 16.3431 13 18C13 19.6569 14.3431 21 16 21Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M17 34C18.6569 34 20 32.6569 20 31C20 29.3431 18.6569 28 17 28C15.3431 28 14 29.3431 14 31C14 32.6569 15.3431 34 17 34Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg>`, title: "外观设置", hint: "调整窗口布局、界面主题与昔涟桌宠" },
   general: { emoji: `<svg width="24" height="24" viewBox="0 0 48 48" fill="none" aria-hidden="true" style="vertical-align:-3px"><title>通用设置</title><path d="M18.2838 43.1713C14.9327 42.1736 11.9498 40.3213 9.58787 37.867C10.469 36.8227 11 35.4734 11 34.0001C11 30.6864 8.31371 28.0001 5 28.0001C4.79955 28.0001 4.60139 28.01 4.40599 28.0292C4.13979 26.7277 4 25.3803 4 24.0001C4 21.9095 4.32077 19.8938 4.91579 17.9995C4.94381 17.9999 4.97188 18.0001 5 18.0001C8.31371 18.0001 11 15.3138 11 12.0001C11 11.0488 10.7786 10.1493 10.3846 9.35011C12.6975 7.1995 15.5205 5.59002 18.6521 4.72314C19.6444 6.66819 21.6667 8.00013 24 8.00013C26.3333 8.00013 28.3556 6.66819 29.3479 4.72314C32.4795 5.59002 35.3025 7.1995 37.6154 9.35011C37.2214 10.1493 37 11.0488 37 12.0001C37 15.3138 39.6863 18.0001 43 18.0001C43.0281 18.0001 43.0562 17.9999 43.0842 17.9995C43.6792 19.8938 44 21.9095 44 24.0001C44 25.3803 43.8602 26.7277 43.594 28.0292C43.3986 28.01 43.2005 28.0001 43 28.0001C39.6863 28.0001 37 30.6864 37 34.0001C37 35.4734 37.531 36.8227 38.4121 37.867C36.0502 40.3213 33.0673 42.1736 29.7162 43.1713C28.9428 40.752 26.676 39.0001 24 39.0001C21.324 39.0001 19.0572 40.752 18.2838 43.1713Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M24 31C27.866 31 31 27.866 31 24C31 20.134 27.866 17 24 17C20.134 17 17 20.134 17 24C17 27.866 20.134 31 24 31Z" fill="none" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/></svg>`, title: "通用设置", hint: "管理窗口、音频和系统行为" },
@@ -1552,6 +1555,7 @@ function switchSection(section: string): void {
   const isTts = section === "tts";
   const isAsr = section === "asr";
   const isMusic = section === "music";
+  const isFeaturePlugins = section === "feature-plugins";
   apiForm.classList.toggle("is-hidden", !isApi);
   apiRuntimeForm.classList.toggle("is-hidden", !isApiAdvanced);
   appearanceForm.classList.toggle("is-hidden", !isAppearance);
@@ -1580,9 +1584,11 @@ function switchSection(section: string): void {
   if (musicPanel) musicPanel.classList.toggle("is-hidden", !isMusic);
   if (isMusic) void loadMusicPanel();
   else disposeMusicPanel();
+  featurePluginsPanel?.classList.toggle("is-hidden", !isFeaturePlugins);
+  if (isFeaturePlugins) void renderFeaturePlugins();
   placeholderPanel.classList.toggle(
     "is-hidden",
-    isApi || isApiAdvanced || isAppearance || isGeneral || isPreferences || isCyrene || isDisclaimer || isMemory || isUser || isTasks || isPlugins || isTokens || isChannels || isTts || isAsr || isMusic,
+    isApi || isApiAdvanced || isAppearance || isGeneral || isPreferences || isCyrene || isDisclaimer || isMemory || isUser || isTasks || isPlugins || isTokens || isChannels || isTts || isAsr || isMusic || isFeaturePlugins,
   );
 
   if (
@@ -1601,7 +1607,8 @@ function switchSection(section: string): void {
     !isChannels &&
     !isTts &&
     !isAsr &&
-    !isMusic
+    !isMusic &&
+    !isFeaturePlugins
   ) {
 	    placeholderIcon.innerHTML = label.emoji;
     placeholderTitle.textContent = label.title;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -413,6 +413,7 @@ export const IPC = {
   PLUGINS_SET_ENABLED: "plugins:set-enabled",
   PLUGINS_OPEN: "plugins:open",
   PLUGINS_RESCAN: "plugins:rescan",
+  PLUGINS_UNINSTALL: "plugins:uninstall",
 
 } as const;
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -408,5 +408,10 @@ export const IPC = {
   SCREENSHOT_HOTKEY_CAPTURE_START: "screenshot:hotkey-capture-start",
   SCREENSHOT_HOTKEY_CAPTURE_END: "screenshot:hotkey-capture-end",
 
+  // plugin system
+  PLUGINS_LIST: "plugins:list",
+  PLUGINS_SET_ENABLED: "plugins:set-enabled",
+  PLUGINS_OPEN: "plugins:open",
+
 } as const;
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -412,6 +412,7 @@ export const IPC = {
   PLUGINS_LIST: "plugins:list",
   PLUGINS_SET_ENABLED: "plugins:set-enabled",
   PLUGINS_OPEN: "plugins:open",
+  PLUGINS_RESCAN: "plugins:rescan",
 
 } as const;
 

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -13,6 +13,6 @@
     "declaration": false,
     "sourceMap": true
   },
-  "include": ["src/main/**/*.ts", "src/shared/**/*.ts"],
-  "exclude": ["src/shared/renderer-base.ts", "src/main/**/*.test.ts"]
+  "include": ["src/plugins/**/*.ts", "src/main/**/*.ts", "src/shared/**/*.ts"],
+  "exclude": ["src/shared/renderer-base.ts", "src/main/**/*.test.ts", "src/plugins/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: [
+      "src/plugins/**/*.test.ts",
       "src/main/**/*.test.ts",
       "src/renderer/**/*.test.ts",
       "src/shared/**/*.test.ts",


### PR DESCRIPTION
## 背景与目标

本 PR 为 Cyrene Agent 增加首版运行时插件系统，并根据上游最新审查意见完成第二轮分阶段加固。

上游已经确认原方案中的生命周期串行化、资源所有权、API v1 与失败回滚方向可接受，同时提出三项合并前要求：

1. 将分支 rebase 到最新 `master`，适配新的应用组合根与 `ShutdownCoordinator`；
2. 增加用户插件卸载能力：删除用户插件目录、清除启用状态并重新扫描；
3. 明确 Windows 上用户插件目录是否为 `%APPDATA%\live2d-cyrene\plugins`，并在 rebase 后完成全量测试。

本轮已逐项落实。当前分支直接建立在上游 `734bfeea` 之上，PR 头提交为 `eb641e32`。

## 本轮如何回应上游问题

### 一、已 rebase 最新 master，并适配新版启动链路

本次不是机械解决冲突，而是按新版应用架构重新确认插件运行时的接入边界。

新版主干已将应用启动拆分到 `src/main/application/**`，并将关闭流程统一交给 `ShutdownCoordinator`。因此，本 PR 删除了旧版关闭锁存器的接入方式，没有恢复已经被上游删除的旧文件，而是改为使用新版组合根和退出阶段。

新的启动顺序为：

1. 创建 Channels 子系统；
2. 同步执行 `channels.initialize()`，注册全部内置渠道适配器；
3. 等待 `channels.adaptersRegistered` 明确完成；
4. 启动插件运行时；
5. 再继续加载聊天数据、RAG 等核心服务；
6. 后台阶段异步启动渠道网络连接。

这保证插件只能在内置 `feishu`、微信、QQ 等渠道 ID 已被宿主占有后启动，无法抢先注册同名渠道。与此同时，慢速网络连接仍留在后台阶段，不会阻塞应用核心启动。

如果同步渠道初始化抛出异常，`adaptersRegistered` 会同步转为 rejected，插件运行时不会越过失败边界继续启动。对应成功、等待和失败路径均增加了自动化测试。

### 二、已接入新版 ShutdownCoordinator

插件停止现在注册在 `stopActiveWork` 阶段；内置 Channels 停止保留在 `stopExternalConsumers` 阶段。因此受控退出顺序固定为：

1. 停止插件并等待插件 `unregister()`；
2. 释放插件拥有的工具、IPC 和渠道适配器；
3. 再停止内置 Channels 与外部消费者；
4. 最后关闭截图、LSP、Git、音乐等本地资源并执行退出动作。

新版协调器的总等待上限为 10 秒。测试直接触发受控退出并断言 `plugins-stop` 严格早于 `channels-stop`，避免只验证“注册了回调”却没有验证真实阶段顺序。

### 三、插件 IPC 已复用新版共享作用域

rebase 后插件 IPC 不再维护一套与主干平行的清理机制，而是接入新版 `IpcScope`。作用域支持动态移除单个 handler，同时仍会在整体 dispose 时兜底清理剩余 handler；测试覆盖了已动态移除的 handler 不会在 dispose 时重复注销。

### 四、已增加 `plugins:uninstall`

新增完整调用链：

- Shared IPC：`plugins:uninstall`；
- Preload：`window.plugins.uninstall(id)`；
- Main：`PluginManager.uninstall(id)`；
- Settings UI：仅用户插件显示“卸载”按钮，并在删除前进行二次确认。

卸载继续进入插件管理器的同一条串行操作队列，不会与 enable、disable、rescan 或应用退出并发交错。

卸载事务顺序如下：

1. 校验插件存在且来源为 `user`，内置插件明确拒绝卸载；
2. 校验插件目录是已配置用户插件根目录的一级普通目录；
3. 通过 `realpath` 再次确认真实路径未越出用户插件根目录，拒绝目录符号链接与路径逃逸；
4. 停止插件并释放工具、IPC、渠道适配器等运行资源；
5. 清除并持久化该插件的启用状态；
6. 在第三方 `unregister()` 返回后再次执行目录安全校验，降低清理阶段替换目标路径的风险；
7. 清理模块缓存，递归删除插件程序目录；
8. 执行一次不会重启其他活动插件的增量重扫，并刷新设置页状态。

失败语义也做了明确处理：

- 启停状态持久化失败时，不删除插件目录；
- 目录删除失败时，插件保持停用并显示可见错误，避免下次启动自动执行；
- 路径校验失败时，不停用、不删除目标；
- 内置插件没有卸载入口，Main 侧也会再次拒绝，不能依赖 UI 隐藏作为安全边界。

卸载只删除插件程序目录 `userData/plugins/<plugin-id>/`，默认保留 `userData/plugin-data/<plugin-id>/`。确认弹窗、设置页提示和插件作者文档都明确说明了这一点，避免用户误以为插件数据也会被删除。

### 五、Windows 用户插件目录确认

是，打包版 Windows 默认目录为：

```text
%APPDATA%\live2d-cyrene\plugins\<plugin-id>\
```

实现不是硬编码 `%APPDATA%`，而是使用 Electron `app.getPath("userData")` 后拼接 `plugins`。当前包名为 `live2d-cyrene`，所以默认展开为上述路径；如果开发或测试环境显式覆盖 `userData`，插件目录会跟随实际返回路径变化。

## 插件系统整体能力

### 插件发现与清单校验

- 分开扫描内置插件和用户插件来源；
- `manifest.json` 必须声明当前支持的 `apiVersion: 1`；
- 插件版本使用严格 SemVer；
- `deps` 只接受当前支持的 `channels`、`llm`；
- 严格校验入口文件、扩展名、普通文件属性和真实路径；
- 单插件错误和扫描根目录错误转为结构化 issue，不阻断应用启动；
- 用户插件首次发现一律停用，必须由用户显式授权启用。

### 稳定 Plugin API v1

- `src/plugins/api.ts` 不依赖 `src/main/**` 或 `src/shared/**` 内部类型；
- 提供工具、插件命名空间 IPC、渠道适配器、宿主 LLM 与私有存储能力；
- 插件 LLM 请求复用宿主供应商解析、队列、用量统计、日志和取消链路；
- 当前模型明确为“可信本地原生插件”，不是进程隔离或权限沙箱。

### 资源所有权与失败回滚

- Context 跟踪每个插件实际拥有的工具、IPC 和渠道资源；
- 插件只能注销自身资源；
- 重复工具、IPC 或渠道 ID 会被明确拒绝；
- `register()` 中途失败时，先尽力调用插件 `unregister()`，再由宿主兜底回收已登记资源；
- 正常停用、卸载和应用退出时，即使插件清理抛错，宿主仍继续回收资源。

### 生命周期与可观察性

- 区分用户期望状态 `configuredEnabled` 与实际状态；
- 状态包括 `disabled`、`starting`、`running`、`stopping`、`failed`；
- enable、disable、open、rescan、uninstall、stop 全部串行执行；
- 设置页显示来源、接口版本、目录、状态、持久错误和扫描问题；
- 活动插件重扫时会卸载并重新加载，模块缓存同步清理。

## 本轮主要文件

- `src/main/application/core-bootstrap.ts`：在内置 adapter 就绪后启动插件，并将插件停止注册到新版退出阶段；
- `src/main/application/default-dependencies.ts`：在新版组合根注入插件运行时；
- `src/main/application/ipc-scope.ts`：支持插件 handler 的动态、幂等清理；
- `src/main/channels/bootstrap.ts`：提供 `adaptersRegistered` 明确边界；
- `src/main/plugin-runtime.ts`：适配新版工具注册表与共享 IPC 作用域；
- `src/plugins/manager.ts`：生命周期、重扫、失败回滚及安全卸载事务；
- `src/preload/index.ts`、`src/shared/ipc-channels.ts`：卸载 IPC 桥接；
- `src/renderer/settings/feature-plugins/**`：用户插件卸载 UI 与错误反馈；
- `docs/plugins/plugin-authoring.md`：Windows 路径、卸载语义、新版退出阶段和验证清单。

## 验证结果

### 完整构建

`npm run build` 已通过，包括：

- Main TypeScript 构建；
- Preload TypeScript 构建；
- CLI 打包；
- Renderer 生产构建。

Renderer 仅输出既有的大 chunk 提示，没有构建错误。

### 插件与接入专项回归

以下 10 个测试文件共 `74/74` 项通过：

- `src/main/application/ipc-scope.test.ts`
- `src/main/application/core-bootstrap.test.ts`
- `src/main/channels/bootstrap.test.ts`
- `src/main/channels/manager.test.ts`
- `src/plugins/loader.test.ts`
- `src/plugins/context.test.ts`
- `src/plugins/manager.test.ts`
- `src/plugins/storage.test.ts`
- `src/main/plugin-llm.test.ts`
- `src/renderer/settings/feature-plugins/panel.test.ts`

新增覆盖包括：等待内置 adapter 边界、初始化失败拒绝边界、受控退出阶段顺序、用户插件卸载、内置插件卸载拒绝、路径越界拒绝、状态持久化失败不删除、插件数据保留、仅用户插件显示卸载按钮及确认交互。

### 全量测试

- 受限沙箱内：`2898/2901` 通过；
- 其余 3 项均因既有测试向固定的 `C:\cyrene-test-user-data` 或 `C:\cyrene-characterization` 写入时触发 `EPERM`；
- 在允许固定目录写入的环境中单独复跑这 2 个测试文件：`3/3` 通过；
- 综合验证：全部 `2901/2901` 项均已取得通过结果。

## 风险与明确边界

- 插件仍在 Electron Main Process 中运行，拥有与宿主相同的本机权限；路径校验、首次默认关闭和所有权控制不能替代真正的进程沙箱。
- 本 PR 不包含插件市场、签名、自动下载、自动更新、渲染进程任意代码注入或细粒度网络/文件/命令权限。
- 卸载默认保留插件私有数据；彻底清理数据应作为独立、需要用户再次确认的操作设计。
- 重新扫描活动插件时会短暂停用后重启该插件，但串行队列保证不会发生重复注册。

## 建议审查顺序

1. `src/main/application/core-bootstrap.ts` 与 `src/main/channels/bootstrap.ts`：确认新版启动/退出顺序；
2. `src/plugins/manager.ts`：确认生命周期、失败语义与安全卸载事务；
3. `src/plugins/context.ts` 与 `src/plugins/api.ts`：确认所有权和公开接口边界；
4. `src/plugins/loader.ts`：确认清单和真实路径校验；
5. Preload、Settings UI 与文档：确认用户交互和数据保留语义；
6. 对应测试：确认关键顺序、安全失败路径与回归证据。
