### PR TITLE
feat(log): 落盘打包版主进程日志到 userData/logs/cyrene.log（滚动 3 份 × 5MB）

### DIFF
--- a/src/main/log-sink-file.test.ts
+++ b/src/main/log-sink-file.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,12 +11,19 @@ import {
 } from "./log-sink-file";
 
 let tmpDir: string;
+let outSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cyrene-log-sink-"));
+  // e2e 用例走真实 logger：拦截 stdout/stderr，避免测试输出泄漏脏行
+  outSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 });
 
 afterEach(() => {
+  outSpy.mockRestore();
+  errSpy.mockRestore();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -71,6 +78,17 @@ describe("createFileLogSink", () => {
     const logPath = path.join(tmpDir, "no-such-dir", "cyrene.log");
     const sink = createFileLogSink(logPath);
     expect(() => sink(makeEntry())).not.toThrow();
+  });
+
+  it("rotates automatically on write when the file exceeds maxBytes", () => {
+    // 注入小 maxBytes，走真实的"写入 → 轮转 → 追加"链路
+    const logPath = path.join(tmpDir, "cyrene.log");
+    const sink = createFileLogSink(logPath, 40);
+    sink(makeEntry({ message: "big-entry", line: "INFO  Cyrene         big-entry" }));
+    sink(makeEntry({ message: "next", line: "INFO  Cyrene         next" }));
+    expect(fs.existsSync(logPath + ".1")).toBe(true);
+    expect(fs.readFileSync(logPath + ".1", "utf8")).toContain("big-entry");
+    expect(fs.readFileSync(logPath, "utf8")).toContain("next");
   });
 });
 

--- a/src/main/log-sink-file.test.ts
+++ b/src/main/log-sink-file.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setLogLevel, logger, type LogEntry } from "../shared/logger";
+import {
+  formatTs,
+  rotateIfNeeded,
+  createFileLogSink,
+  installFileLogSink,
+} from "./log-sink-file";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cyrene-log-sink-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeEntry(partial: Partial<LogEntry> = {}): LogEntry {
+  return {
+    ts: new Date(2026, 8, 1, 9, 32, 24, 123).getTime(),
+    level: "info",
+    tag: "Cyrene",
+    message: "hello",
+    line: "INFO  Cyrene         hello",
+    ...partial,
+  };
+}
+
+describe("formatTs", () => {
+  it("formats epoch ms as local YYYY-MM-DD HH:MM:SS.mmm", () => {
+    // 2026-09-01 09:32:24.123（本地时区）
+    const ts = new Date(2026, 8, 1, 9, 32, 24, 123).getTime();
+    expect(formatTs(ts)).toBe("2026-09-01 09:32:24.123");
+  });
+
+  it("zero-pads month/day/hour/minute/second/millisecond", () => {
+    const ts = new Date(2026, 0, 5, 7, 8, 9, 10).getTime();
+    expect(formatTs(ts)).toBe("2026-01-05 07:08:09.010");
+  });
+});
+
+describe("createFileLogSink", () => {
+  it("appends a timestamped line to the file", () => {
+    const logPath = path.join(tmpDir, "cyrene.log");
+    const sink = createFileLogSink(logPath);
+    sink(makeEntry());
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("2026-09-01 09:32:24.123");
+    expect(content).toContain("INFO  Cyrene         hello");
+  });
+
+  it("appends multiple entries in order", () => {
+    const logPath = path.join(tmpDir, "cyrene.log");
+    const sink = createFileLogSink(logPath);
+    sink(makeEntry({ message: "first", line: "INFO  Cyrene         first" }));
+    sink(makeEntry({ message: "second", line: "INFO  Cyrene         second" }));
+    const content = fs.readFileSync(logPath, "utf8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("first");
+    expect(lines[1]).toContain("second");
+  });
+
+  it("survives append failures without throwing", () => {
+    // 指向一个不存在的目录：appendFileSync 会抛，sink 必须静默吞掉
+    const logPath = path.join(tmpDir, "no-such-dir", "cyrene.log");
+    const sink = createFileLogSink(logPath);
+    expect(() => sink(makeEntry())).not.toThrow();
+  });
+});
+
+describe("rotateIfNeeded", () => {
+  it("rotates when the current file exceeds maxBytes", () => {
+    const logPath = path.join(tmpDir, "cyrene.log");
+    fs.writeFileSync(logPath, "x".repeat(100));
+    rotateIfNeeded(logPath, 50);
+    expect(fs.existsSync(logPath + ".1")).toBe(true);
+    expect(fs.readFileSync(logPath + ".1", "utf8").length).toBe(100);
+  });
+
+  it("keeps at most MAX_FILES generations", () => {
+    const logPath = path.join(tmpDir, "cyrene.log");
+    for (let gen = 1; gen <= 5; gen++) {
+      fs.writeFileSync(logPath, "g".repeat(100));
+      rotateIfNeeded(logPath, 50);
+    }
+    expect(fs.existsSync(logPath + ".1")).toBe(true);
+    expect(fs.existsSync(logPath + ".2")).toBe(true);
+    expect(fs.existsSync(logPath + ".3")).toBe(false); // 只保留 .1/.2 两代
+  });
+
+  it("does nothing when the file does not exist", () => {
+    const logPath = path.join(tmpDir, "cyrene.log");
+    expect(() => rotateIfNeeded(logPath, 50)).not.toThrow();
+    expect(fs.existsSync(logPath + ".1")).toBe(false);
+  });
+});
+
+describe("installFileLogSink", () => {
+  it("writes to <userData>/logs/cyrene.log and returns an uninstall fn", () => {
+    const uninstall = installFileLogSink(tmpDir);
+    try {
+      setLogLevel("info");
+      logger.info("Cyrene", "sink-e2e");
+      const logPath = path.join(tmpDir, "logs", "cyrene.log");
+      expect(fs.existsSync(logPath)).toBe(true);
+      expect(fs.readFileSync(logPath, "utf8")).toContain("sink-e2e");
+    } finally {
+      uninstall();
+      // 卸载后不再写入
+      const logPath = path.join(tmpDir, "logs", "cyrene.log");
+      const before = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+      logger.info("Cyrene", "after-uninstall");
+      const after = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+      expect(after).toBe(before);
+    }
+  });
+});

--- a/src/main/log-sink-file.ts
+++ b/src/main/log-sink-file.ts
@@ -1,0 +1,84 @@
+/**
+ * 打包版日志落盘（file log sink）。
+ *
+ * 背景：打包后的 Electron 主进程 stdout/stderr 在用户机器上默认不可见
+ * （还可能断管，见 21388fe），出 bug 时用户无从排查、issue 也无法附日志。
+ * 这里把 logger 输出同步落盘到 userData/logs/cyrene.log，单文件超过上限后
+ * 滚动（保留 MAX_FILES 份），用户/issue 上报可直接附上日志文件。
+ *
+ * 设计：
+ *  - 本模块不依赖 electron，日志目录由调用方注入（src/main/logger.ts 用
+ *    app.getPath("userData")），便于单测。
+ *  - 同步 appendFileSync：主进程日志量级很小，简单可靠胜过流式状态管理。
+ *  - 磁盘错误静默吞掉：日志系统自身故障不能反过来干扰业务。
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { addLogSink, type LogEntry } from "../shared/logger";
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024; // 5MB / 份
+const MAX_FILES = 3; // cyrene.log / cyrene.log.1 / cyrene.log.2
+
+/** 时间戳格式化：2026-09-01 09:32:24.123 */
+export function formatTs(ts: number): string {
+  const d = new Date(ts);
+  const p = (n: number, w = 2): string => String(n).padStart(w, "0");
+  return (
+    `${p(d.getFullYear(), 4)}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`
+  );
+}
+
+/**
+ * 轮转：当前文件超过上限时，.2 ← .1 ← 当前，并新开当前文件。
+ * 文件不存在视为无需轮转。
+ */
+export function rotateIfNeeded(logPath: string, maxBytes = DEFAULT_MAX_BYTES): void {
+  try {
+    const st = fs.statSync(logPath);
+    if (st.size < maxBytes) return;
+  } catch {
+    return; // 不存在或 stat 失败：无需轮转
+  }
+  for (let i = MAX_FILES - 2; i >= 1; i--) {
+    const from = `${logPath}.${i}`;
+    const to = `${logPath}.${i + 1}`;
+    try {
+      fs.renameSync(from, to);
+    } catch {
+      // 源不存在：跳过
+    }
+  }
+  try {
+    fs.renameSync(logPath, `${logPath}.1`);
+  } catch {
+    // 忽略：极端情况（占用等）下放弃本轮轮转
+  }
+}
+
+/** 创建文件落盘接收器。maxBytes 可注入以便测试轮转。 */
+export function createFileLogSink(
+  logPath: string,
+  maxBytes = DEFAULT_MAX_BYTES,
+): (entry: LogEntry) => void {
+  return (entry: LogEntry): void => {
+    const line = `${formatTs(entry.ts)} ${entry.line}\n`;
+    try {
+      rotateIfNeeded(logPath, maxBytes);
+      fs.appendFileSync(logPath, line, "utf8");
+    } catch {
+      // 磁盘/权限错误：静默，日志系统不能反过来报错
+    }
+  };
+}
+
+/**
+ * 安装文件落盘接收器（主进程启动时调用一次）。
+ * @param userDataDir Electron app.getPath("userData") 的结果
+ * @returns 卸载函数（测试用）
+ */
+export function installFileLogSink(userDataDir: string): () => void {
+  const dir = path.join(userDataDir, "logs");
+  fs.mkdirSync(dir, { recursive: true });
+  return addLogSink(createFileLogSink(path.join(dir, "cyrene.log")));
+}

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -10,6 +10,7 @@
 import { app } from "electron";
 import { setLogLevel, type LogLevel } from "../shared/logger";
 import { logger } from "../shared/logger";
+import { installFileLogSink } from "./log-sink-file";
 
 function resolveDefaultLevel(): LogLevel {
   // env wins
@@ -24,6 +25,14 @@ function resolveDefaultLevel(): LogLevel {
 }
 
 setLogLevel(resolveDefaultLevel());
+
+// 打包版 stdout 不可见：把日志同步落盘到 userData/logs/cyrene.log（滚动 3 份×5MB），
+// 用户/issue 上报可直接附日志文件。dev 下同样落盘，便于本地排查。
+try {
+  installFileLogSink(app.getPath("userData"));
+} catch {
+  // userData 不可用时静默跳过，日志落盘只是增强项
+}
 
 export { logger, setLogLevel, LogTag } from "../shared/logger";
 export type { LogLevel } from "../shared/logger";

--- a/src/shared/logger.test.ts
+++ b/src/shared/logger.test.ts
@@ -3,7 +3,10 @@ import {
   logger,
   setLogLevel,
   getLogLevel,
+  addLogSink,
+  removeLogSink,
   type LogLevel,
+  type LogEntry,
 } from "./logger";
 import { LogTag } from "./logger-tags";
 
@@ -112,6 +115,80 @@ describe("all LogTag values are <= 16 chars", () => {
       // If a tag were > 16 chars the formatter would silently truncate it.
       // This test fails loudly so we notice and shorten the tag name.
       expect(tag.length).toBeLessThanOrEqual(16);
+    }
+  });
+});
+
+describe("log sinks", () => {
+  const received: LogEntry[] = [];
+  const collect = (entry: LogEntry): void => {
+    received.push(entry);
+  };
+
+  beforeEach(() => {
+    received.length = 0;
+  });
+
+  it("sink receives entries that pass the level gate, with plain line", () => {
+    setLogLevel("info");
+    const unsub = addLogSink(collect);
+    try {
+      logger.info(LogTag.Cyrene, "sink-msg", { k: 1 });
+      expect(received).toHaveLength(1);
+      expect(received[0].level).toBe("info");
+      expect(received[0].tag).toBe(LogTag.Cyrene);
+      expect(received[0].message).toBe('sink-msg {"k":1}');
+      // line 无 ANSI 色码、无时间戳前缀，与 stdout 纯文本格式一致
+      expect(received[0].line).toContain("INFO ");
+      expect(received[0].line).toContain("sink-msg");
+      expect(received[0].line).not.toContain("\x1b[");
+      expect(typeof received[0].ts).toBe("number");
+    } finally {
+      unsub();
+    }
+  });
+
+  it("filtered levels do not reach sinks", () => {
+    setLogLevel("warn");
+    const unsub = addLogSink(collect);
+    try {
+      logger.info(LogTag.Cyrene, "should-not-reach-sink");
+      expect(received).toHaveLength(0);
+    } finally {
+      unsub();
+    }
+  });
+
+  it("unsubscribe stops delivery", () => {
+    setLogLevel("info");
+    const unsub = addLogSink(collect);
+    unsub();
+    logger.info(LogTag.Cyrene, "after-unsub");
+    expect(received).toHaveLength(0);
+  });
+
+  it("removeLogSink stops delivery", () => {
+    setLogLevel("info");
+    addLogSink(collect);
+    removeLogSink(collect);
+    logger.info(LogTag.Cyrene, "after-remove");
+    expect(received).toHaveLength(0);
+  });
+
+  it("a throwing sink does not break stdout output or other sinks", () => {
+    setLogLevel("info");
+    const boom = (): void => {
+      throw new Error("sink boom");
+    };
+    const unsubBoom = addLogSink(boom);
+    const unsubCollect = addLogSink(collect);
+    try {
+      expect(() => logger.info(LogTag.Cyrene, "still-works")).not.toThrow();
+      expect(received).toHaveLength(1);
+      expect(stdoutBuf).toContain("still-works");
+    } finally {
+      unsubBoom();
+      unsubCollect();
     }
   });
 });

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -46,6 +46,41 @@ function readEnvLevel(): LogLevel | null {
   return null;
 }
 
+/**
+ * 日志接收器（sink）机制。
+ *
+ * 默认 logger 只写 stdout/stderr——打包版 Electron 的 stdout 在用户机器上
+ * 默认不可见（甚至可能断管），出问题无从排查。主进程可通过 addLogSink
+ * 注册额外出口（例如落盘 userData/logs/cyrene.log），渲染器进程不注册
+ * 就不受影响。sink 抛错被吞掉，绝不干扰主链路。
+ */
+export interface LogEntry {
+  /** 事件发生时间（epoch ms），落盘侧自行格式化 */
+  ts: number;
+  level: LogLevel;
+  tag: string;
+  /** 格式化后的消息（多参数已拼接、非字符串已 JSON 化） */
+  message: string;
+  /** 与 stdout 一致的纯文本行（无 ANSI 色码），适合落盘/转发 */
+  line: string;
+}
+
+export type LogSink = (entry: LogEntry) => void;
+
+const logSinks = new Set<LogSink>();
+
+/** 注册日志接收器，返回取消函数。 */
+export function addLogSink(sink: LogSink): () => void {
+  logSinks.add(sink);
+  return () => {
+    logSinks.delete(sink);
+  };
+}
+
+export function removeLogSink(sink: LogSink): void {
+  logSinks.delete(sink);
+}
+
 export function setLogLevel(level: LogLevel): void {
   currentLevel = level;
 }
@@ -86,6 +121,20 @@ function emit(level: LogLevel, tag: string, args: unknown[]): void {
   } else {
     const line = `${lvl} ${tagCol} ${message}`;
     (level === "error" || level === "warn" ? process.stderr : process.stdout).write(line + "\n");
+  }
+
+  // 广播给额外接收器（文件落盘等）。发生在 stdout/stderr 写入之后，
+  // 保持原有行为不变；sink 自身异常不影响主链路。
+  if (logSinks.size > 0) {
+    const plainLine = `${lvl} ${tagCol} ${message}`;
+    const entry: LogEntry = { ts: Date.now(), level, tag, message, line: plainLine };
+    for (const sink of logSinks) {
+      try {
+        sink(entry);
+      } catch {
+        // 忽略：日志接收器故障不能反过来拖垮业务日志
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# PR: feat(log): 打包版主进程日志落盘到 userData/logs/cyrene.log（滚动文件）

## 标题（Title）

```
feat(log): 落盘打包版主进程日志到 userData/logs/cyrene.log（滚动 3 份 × 5MB）
```

## 描述（Body）

```markdown
> **背景来源**：本 PR 源自「Cyrene 实时语音修复」排查项目。实时语音通话
> 链路（ASR → LLM → TTS）出问题时，主进程（CallManager/ASR/TTS）的
> stdout/stderr 在打包版中完全不可见，只能靠界面报错猜原因——本 PR
> 把这段"看不见的日志"落盘，让用户/issue 上报时有据可查。

打包版 Electron 的主进程 stdout/stderr 在用户机器上默认不可见（甚至可能
断管，见 21388fe 的防断管处理）。用户出 bug 时无从排查，issue 也无法
附上日志——只能靠用户复述"什么现象"，维护成本极高。

本 PR 给日志系统加一个"接收器（sink）"机制：默认 stdout/stderr 行为完全
不变，主进程额外注册一个文件接收器，把日志同步落盘到
`userData/logs/cyrene.log`，单文件超 5MB 滚动，保留 3 份
（cyrene.log / .1 / .2）。用户/issue 上报时直接附上日志文件即可。

## 改动

### src/shared/logger.ts — 接收器机制（无 Electron 依赖）

- 新增 `LogEntry` 接口（ts/level/tag/message/line），`line` 是与 stdout
  一致的纯文本行（无 ANSI 色码），适合落盘
- 新增 `addLogSink(sink) -> 取消函数` / `removeLogSink(sink)`
- `emit()` 在写完 stdout/stderr 之后广播给所有接收器；单个 sink 抛错被
  吞掉，绝不影响主链路
- 渲染器进程不注册接收器，完全不受影响

### src/main/log-sink-file.ts — 文件落盘（新文件，纯逻辑可单测）

- `formatTs()`：本地时区 `YYYY-MM-DD HH:MM:SS.mmm`
- `rotateIfNeeded()`：超限轮转（.2 ← .1 ← 当前），最多保留 3 份
- `createFileLogSink()`：同步 appendFileSync 落盘，磁盘错误静默
- `installFileLogSink(userDataDir)`：mkdir userData/logs 后注册，返回卸载函数

### src/main/logger.ts — 启动时安装

- 模块初始化时调用 `installFileLogSink(app.getPath("userData"))`，
  userData 不可用时静默跳过（日志落盘只是增强项）

## 测试

- `src/main/log-sink-file.test.ts`（新增 8 用例）：
  formatTs 零填充 / 追加写入顺序 / append 失败静默 / 轮转触发 / 最多 3 份 /
  文件不存在不报错 / install 端到端写入 + 卸载后不再写
- `src/shared/logger.test.ts`（追加 3 用例）：
  sink 收到过级别门槛的条目（含纯文本 line）/ 被过滤级别不进 sink /
  sink 抛错不影响 stdout 与其他 sink

## 验证

- `npm test` 全量通过
- 手动验证：打包版启动后 `%APPDATA%\live2d-cyrene\logs\cyrene.log`
  持续追加启动日志

## 为什么不落盘到 renderer

渲染器日志走 devtools 即可；本 PR 解决的是主进程（CallManager/ASR/TTS
等）在打包环境下的可观测性，这才是用户场景里看不见的那部分。
```

## Commit 规划

```
feat(log): shared logger 增加 sink 接收器机制
feat(log): 主进程日志落盘 userData/logs/cyrene.log（滚动 3×5MB）
test(log): 文件落盘与 sink 机制单测
```

## 推送后开 PR

- 目标分支：`master`
- 源分支：`feat/log-file-sink`
- PR 链接：https://github.com/Playa-0v0/Cyrene-Agent/compare/master...chuxuan:feat/log-file-sink
