### PR TITLE
test(log): 拦截单测 stdout 输出并补 sink 写入触发轮转用例

### DIFF
--- a/src/main/log-sink-file.test.ts
+++ b/src/main/log-sink-file.test.ts
@@ -138,4 +138,33 @@ describe("installFileLogSink", () => {
       expect(after).toBe(before);
     }
   });
+
+  it("rotates through the real logger with a small maxBytes", () => {
+    // 全链路：logger.emit → stdout(spy 拦截) → logSinks 广播 →
+    // createFileLogSink → rotateIfNeeded(超限滚动) → appendFileSync(追加)。
+    // installFileLogSink 注入 80 字节阈值，通过真实 logger 走通"写入→轮转→追加"。
+    const uninstall = installFileLogSink(tmpDir, 80);
+    try {
+      setLogLevel("info");
+      const logPath = path.join(tmpDir, "logs", "cyrene.log");
+
+      // 阶段一：连续写入，每行约 120 字节 > 80 阈值 → 每次写入触发轮转
+      // 滚动规则：当前文件超限 → .1 ← 当前，.2 ← .1（最多保留 3 份，最老淘汰）
+      for (let i = 0; i < 5; i++) {
+        logger.info("Cyrene", `rotation-${i}-${"x".repeat(60)}`);
+      }
+      // 5 次写入后：当前=[rot4], .1=[rot3], .2=[rot2]，rot0/rot1 已淘汰
+      expect(fs.existsSync(logPath + ".1")).toBe(true);
+      expect(fs.readFileSync(logPath + ".1", "utf8")).toContain("rotation-3");
+      expect(fs.existsSync(logPath + ".2")).toBe(true);
+      expect(fs.readFileSync(logPath + ".2", "utf8")).toContain("rotation-2");
+      expect(fs.readFileSync(logPath, "utf8")).toContain("rotation-4");
+
+      // 阶段二：轮转后继续追加，当前文件应包含最新一行（真实追加链路）
+      logger.info("Cyrene", "after-rotate");
+      expect(fs.readFileSync(logPath, "utf8")).toContain("after-rotate");
+    } finally {
+      uninstall();
+    }
+  });
 });

--- a/src/main/log-sink-file.ts
+++ b/src/main/log-sink-file.ts
@@ -75,10 +75,14 @@ export function createFileLogSink(
 /**
  * 安装文件落盘接收器（主进程启动时调用一次）。
  * @param userDataDir Electron app.getPath("userData") 的结果
+ * @param maxBytes 单文件滚动阈值，测试可注入小值触发真实轮转链路
  * @returns 卸载函数（测试用）
  */
-export function installFileLogSink(userDataDir: string): () => void {
+export function installFileLogSink(
+  userDataDir: string,
+  maxBytes = DEFAULT_MAX_BYTES,
+): () => void {
   const dir = path.join(userDataDir, "logs");
   fs.mkdirSync(dir, { recursive: true });
-  return addLogSink(createFileLogSink(path.join(dir, "cyrene.log")));
+  return addLogSink(createFileLogSink(path.join(dir, "cyrene.log"), maxBytes));
 }


### PR DESCRIPTION
# PR: test(log): 拦截单测 stdout 输出并补 sink 写入触发轮转用例

## 背景

PR #47（主进程日志落盘）合并后，上游 master 已自行补充了
「stdout/stderr spy 拦截」与「createFileLogSink 直接调用触发的轮转用例」。
但**真实 logger 的端到端轮转链路**（`logger.emit` → sink 广播 → 落盘 →
超限滚动 → 继续追加）仍无覆盖，且 `installFileLogSink` 无法注入滚动阈值。

本 PR 补齐这最后一块：通过真实 logger 走通「写入 → 轮转 → 追加」全链路。

## 链路如何实现（本 PR 覆盖的链路）

```
logger.info(...)
  └─ emit(level, tag, args)                       [src/shared/logger.ts]
      ├─ (level ≤ 阈值?) 否 → 直接返回
      ├─ 写 process.stdout/stderr                  ← 单测被 vi.spyOn 拦截，不泄漏脏行
      └─ logSinks 非空 → 构造 LogEntry 并广播给所有 sink
          └─ createFileLogSink(logPath, maxBytes) [src/main/log-sink-file.ts]
              ├─ rotateIfNeeded(logPath, maxBytes)
              │   └─ 当前文件 ≥ maxBytes？
              │       ├─ 是 → .2 ← .1 ← 当前（最多保留 3 份，最老淘汰）
              │       └─ 否 → 不动
              └─ fs.appendFileSync(logPath, line)  ← 追加落盘（同步，错误静默）
```

`installFileLogSink` 新增可选 `maxBytes` 参数（默认 5MB，与
`createFileLogSink` 一致），测试注入 80 字节阈值，即可通过**真实 logger**
触发完整轮转，不再需要直接调 sink 函数。

## 改动

### src/main/log-sink-file.ts（+8/-2）

- `installFileLogSink(userDataDir, maxBytes = DEFAULT_MAX_BYTES)`：
  新增可选 `maxBytes` 参数并透传给 `createFileLogSink`，生产默认 5MB
  行为不变，测试可注入小值触发真实轮转

### src/main/log-sink-file.test.ts（+29）

- 新增用例 `rotates through the real logger with a small maxBytes`：
  - 阶段一：真实 `logger.info` 连续写入 5 行（每行约 120B > 80B 阈值），
    每次写入都触发轮转；断言 `当前=[rot4]`、`.1=[rot3]`、`.2=[rot2]`，
    最老两代（rot0/rot1）已被 3 份上限淘汰
  - 阶段二：轮转后继续 `logger.info` 追加，断言当前文件包含最新行
    （真实追加链路）
- 依赖上游已有的顶层 `vi.spyOn(process.stdout/stderr, "write")`，
  单测跑真实 logger 时输出不会泄漏到测试控制台

## 测试

- `src/main/log-sink-file.test.ts`（11 用例）全过
- `src/shared/logger.test.ts`（17 用例）全过
- 共 28 用例全绿

## 为什么还要走真实 logger

直接调 `createFileLogSink` 只覆盖 sink 函数本身；真实链路覆盖
`logger.emit` 的级别过滤、stdout 写入、sink 广播三个前置环节，
防止"函数能轮转但接进 logger 后不生效"这类集成回归。
