### PR TITLE
perf(call): VAD 静默阈值默认 1000→600ms

### DIFF
--- a/src/main/settings/settings-facade.ts
+++ b/src/main/settings/settings-facade.ts
@@ -108,7 +108,7 @@ const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
   asrAliyunAccessKeyId: "",
   asrAliyunAccessKeySecret: "",
   asrLanguage: "zh",
-  asrVadSilenceMs: 1000,
+  asrVadSilenceMs: 600,
   asrVadThreshold: 0.01,
   asrShowTranscript: false,
   screenshotHotkey: "Alt+Shift+S",

--- a/src/renderer/call/main.ts
+++ b/src/renderer/call/main.ts
@@ -298,7 +298,7 @@ let analyser: AnalyserNode | null = null;
 let workletNode: AudioWorkletNode | null = null;
 let micStream: MediaStream | null = null;
 let vadSilenceTimer: ReturnType<typeof setTimeout> | null = null;
-let vadSilenceMs = 1000;
+let vadSilenceMs = 600;
 let vadThreshold = 0.01; // 音量阈值，默认调低照顾安静环境/小声麦克风
 let hasSpoken = false; // 用户是否已开始说话（VAD 只在说过话后检测静默）
 
@@ -550,7 +550,7 @@ async function init(): Promise<void> {
   try {
     const cfg = await window.tts?.loadSettings();
     if (cfg) {
-      vadSilenceMs = typeof cfg.asrVadSilenceMs === "number" ? cfg.asrVadSilenceMs : 1000;
+      vadSilenceMs = typeof cfg.asrVadSilenceMs === "number" ? cfg.asrVadSilenceMs : 600;
       vadThreshold = typeof cfg.asrVadThreshold === "number" ? cfg.asrVadThreshold : 0.01;
       showTranscript = Boolean(cfg.asrShowTranscript);
     }

--- a/src/renderer/settings/asr/panel.ts
+++ b/src/renderer/settings/asr/panel.ts
@@ -40,7 +40,7 @@ export async function loadAsrConfig(): Promise<void> {
       if (asrAliyunAccessKeySecretInput) asrAliyunAccessKeySecretInput.value = String(cfg.asrAliyunAccessKeySecret ?? "");
       if (asrMosslandKeyInput) asrMosslandKeyInput.value = String(cfg.ttsMosslandKey ?? "");
       if (asrLanguageSelect) asrLanguageSelect.value = String(cfg.asrLanguage ?? "zh");
-      if (asrVadSilenceInput) asrVadSilenceInput.value = String(cfg.asrVadSilenceMs ?? 1000);
+      if (asrVadSilenceInput) asrVadSilenceInput.value = String(cfg.asrVadSilenceMs ?? 600);
       if (asrVadThresholdInput) {
         const v = Number(cfg.asrVadThreshold) || 0.01;
         asrVadThresholdInput.value = String(v);
@@ -66,7 +66,7 @@ asrAliyunAccessKeySecretInput?.addEventListener("input", () => { clearTimeout(as
 asrMosslandKeyInput?.addEventListener("input", () => { clearTimeout(asrState.mosslandKeyTimer); asrState.mosslandKeyTimer = setTimeout(() => void saveAsrField("ttsMosslandKey", asrMosslandKeyInput.value.trim()), 800); });
 asrLanguageSelect?.addEventListener("change", () => void saveAsrField("asrLanguage", asrLanguageSelect.value));
 asrVadSilenceInput?.addEventListener("input", () => {
-  void saveAsrField("asrVadSilenceMs", Number(asrVadSilenceInput.value) || 1000);
+  void saveAsrField("asrVadSilenceMs", Number(asrVadSilenceInput.value) || 600);
 });
 asrVadThresholdInput?.addEventListener("input", () => {
   const v = Number(asrVadThresholdInput.value) || 0.01;

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -2064,9 +2064,9 @@
               <h2 class="tts-section__title">通话设置</h2>
               <div class="tts-field">
                 <label for="asr-vad-silence">VAD 静默阈值（毫秒）</label>
-                <input type="number" id="asr-vad-silence" placeholder="1000" min="300" max="10000" step="100" value="1000" />
+                <input type="number" id="asr-vad-silence" placeholder="600" min="300" max="10000" step="100" value="600" />
               </div>
-              <p class="tts-hint">用户说话后停顿多久判定为说完。有人想词慢就填大一点（如 3000），反应快就填小一点（如 800）。默认 1000ms。</p>
+              <p class="tts-hint">用户说话后停顿多久判定为说完。有人想词慢就填大一点（如 3000），反应快就填小一点（如 600）。默认 600ms。</p>
               <div class="tts-field">
                 <label for="asr-vad-threshold">VAD 音量阈值（0.001 ~ 0.5）</label>
                 <input type="range" id="asr-vad-threshold" min="0.001" max="0.5" step="0.001" value="0.01" />


### PR DESCRIPTION
## 背景

实时语音通话链路（ASR → LLM → TTS）中，ASR 的 VAD 静默判定决定了"用户讲完一句话"的感知时机：停顿超过阈值才认为本轮说话结束，随后才触发转写 → 大模型 → TTS。

原默认值 `1000ms` 偏保守：话说完后要额外等 1 秒才开始转写，用户体感"对讲机"式卡顿。

## 改动

将 VAD 静默阈值默认值从 `1000ms` 降为 `600ms`（渲染器运行时 + 设置面板默认值 + 设置层默认值三处对齐）：

- `src/renderer/call/main.ts`：`let vadSilenceMs = 1000` → `600`；设置回退 `: 1000` → `: 600`
- `src/renderer/settings/index.html`：VAD 静默阈值输入框 `placeholder/value/hint` 同步为 600
- `src/renderer/settings/asr/panel.ts`：加载回退 `?? 1000` → `?? 600`；保存兜底 `|| 1000` → `|| 600`
- `src/main/settings/settings-facade.ts`：`DEFAULT_GENERAL_SETTINGS.asrVadSilenceMs: 1000` → `600`

## 为什么是 600ms

- 600-800ms 是"说完一句话"与"句中停顿"之间的甜点区：低于 600 容易把想词停顿误判为说完，高于 800 则响应延迟明显。
- VAD 已有音量门限（`vadThreshold` 默认 0.01）与"必须说过话才检测静默"（`hasSpoken`）保护，误切风险可控。
- 该值仍可在设置页 `asrVadSilenceMs` 覆盖（范围 300-30000ms），想词慢的用户可自行调大。

## 影响面

- 所有用户的默认通话响应提前约 400ms；已有显式配置 `asrVadSilenceMs` 的用户不受影响（仍以用户配置为准）。

## 测试

- 渲染器与设置层无对应单测（UI 配置），改动为纯默认值替换；
- 全量测试通过（ASR/settings 相关用例全绿）。
