### PR TITLE
为插件提供对话轮次完成宿主事件

### DIFF
--- a/docs/plugins/plugin-authoring.md
+++ b/docs/plugins/plugin-authoring.md
@@ -235,7 +235,13 @@ await ctx.events.emit("status", { online: true });
 `host:chat:message`。目前内置事件：
 
 - `host:plugins:ready`：启动扫描和自动启用完成，payload 为 `{ pluginIds: string[] }`；
-- `host:plugins:stopping`：全局插件停止开始、任何活动插件被注销之前，payload 为 `undefined`。
+- `host:plugins:stopping`：全局插件停止开始、任何活动插件被注销之前，payload 为 `undefined`；
+- `host:turn:completed`：桌面或外部渠道的一轮对话成功完成并执行宿主收尾后发布。首版 payload
+  仅包含 `source`、`mode`、`conversationId` 和可选 `channel` / `runId`，不会广播对话原文，
+  也不会包含完整历史、模型配置或工具内部状态。
+
+轮次完成事件属于旁路通知。宿主不会等待插件监听器，插件应自行排队处理持久化或网络同步，
+并在 `ctx.signal` 取消后尽快停止。若未来确需对话文本，应先单独评审权限和兼容边界。
 
 ### 动态提示词上下文
 

--- a/docs/plugins/plugin-dev-guide.md
+++ b/docs/plugins/plugin-dev-guide.md
@@ -296,8 +296,20 @@ await ctx.events.emit("updated", { value: 1 });
 
 `ctx.events.on()` 返回退订函数；即使不手动调用，停用或刷新插件时也会自动清理，进入停止
 阶段后不能再新增订阅。异步监听器会被等待，某个监听器报错或执行超过 5 秒不会影响其他
-监听器。当前宿主内置事件为
-`host:plugins:ready` 和 `host:plugins:stopping`。
+监听器。当前宿主内置事件为：
+
+- `host:plugins:ready`：插件系统启动完成；
+- `host:plugins:stopping`：插件系统开始停止；
+- `host:turn:completed`：桌面或外部渠道的一轮对话成功完成。首版 payload 仅含
+  `source`、`mode`、`conversationId` 和可选 `channel` / `runId`，不广播对话原文，
+  也不含完整历史、模型配置或工具内部状态。
+
+```js
+ctx.events.on("host:turn:completed", ({ conversationId, source, mode }) => {
+  // 宿主不会等待这里的异步工作；耗时任务应自行排队，并响应 ctx.signal。
+  ctx.log(`${source} 的会话 ${conversationId} 已完成一轮 ${mode} 对话`);
+});
+```
 
 ---
 

--- a/skills/cyrene-plugin-dev/references/api-spec.md
+++ b/skills/cyrene-plugin-dev/references/api-spec.md
@@ -100,9 +100,9 @@ async register(ctx) {
 | `ctx.unregisterTool(id)` | 只能注销本插件注册过的工具 |
 | `ctx.registerPromptProvider(spec)` | 注册每轮动态提示词贡献；id 在当前插件内唯一，可按 chat/work/learn/code 过滤 |
 | `ctx.unregisterPromptProvider(id)` | 只能注销本插件注册过的提示词 Provider |
+| `ctx.events.on(event, listener)` | 订阅 `host:*` 或 `plugin:<id>:*` 事件；停用时自动退订 |
+| `ctx.events.emit(event, payload)` | 发布当前插件自有事件；框架自动添加 `plugin:<id>:` 前缀 |
 | `ctx.registerIpc(channel, handler)` | 注册私有 IPC，实际通道名 `plugin:<id>:<channel>`；channel 只允许字母数字 `.` `_` `-`，≤64 字符 |
-| `ctx.events.on(name, listener)` | 订阅宿主或其他插件事件，返回幂等退订函数；插件停止时自动退订 |
-| `ctx.events.emit(name, payload)` | 发布自己的事件；只能用短名，框架自动补 `plugin:<id>:` 前缀 |
 | `ctx.signal` | 只读 AbortSignal；停止流程开始时先于 `unregister()` 被取消 |
 | `ctx.onDispose(callback)` | 登记兜底清理回调（逆序执行，单个最多 5 秒） |
 | `ctx.storage.set(key, value)` / `ctx.storage.get(key)` | 私有 JSON 存储，key 匹配 `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$` |
@@ -144,7 +144,7 @@ await ctx.events.emit("updated", { value: 1 });
 - `on()` 返回幂等退订函数；插件停用/刷新/卸载时自动退订，进入停止阶段后不能再新增订阅
 - 监听器按订阅顺序执行并等待异步结果；单个失败或超过 5 秒只跳过自己，不影响其他监听器
 - 事件名 segment 只允许字母数字 `.` `_` `-`，≤64 字符
-- 当前内置宿主事件：`host:plugins:ready`（payload `{ pluginIds: string[] }`）、`host:plugins:stopping`（无 payload）
+- 当前内置宿主事件：`host:plugins:ready`（payload `{ pluginIds: string[] }`）、`host:plugins:stopping`（无 payload）、`host:turn:completed`（详见下文）
 
 ---
 
@@ -166,6 +166,23 @@ ctx.registerPromptProvider({
 - 内容进入每轮 runtime context，不修改核心提示词文件或稳定缓存前缀。
 - 多个 Provider 并行生成、按注册顺序拼接；单个最多等待 2 秒、16000 字符，总计最多 32000 字符。
 - 失败、超时或返回空字符串只跳过当前 Provider；插件停止时自动注销。
+
+---
+
+# 宿主对话轮次完成事件
+
+```js
+ctx.events.on("host:turn:completed", ({
+  source, mode, conversationId, channel, runId,
+}) => {
+  // 旁路通知不会阻塞主回复；耗时处理应自行排队，并响应 ctx.signal。
+});
+```
+
+- 仅在桌面或外部渠道的一轮对话成功完成并执行宿主收尾后发布。
+- `source` 为 `desktop` 或 `channel`；`channel` 仅渠道来源提供，`runId` 仅可取得时提供。
+- 首版 payload 只含轮次元数据，不向插件广播用户或助手的对话原文。
+- 不含完整历史、模型配置或工具内部状态；如需文本字段，应另行评审权限与兼容边界。
 
 ---
 

--- a/src/main/agui-bridge.test.ts
+++ b/src/main/agui-bridge.test.ts
@@ -115,6 +115,45 @@ describe("agui-bridge sticker event ordering", () => {
     mocks.completeOnAbort = false;
   });
 
+  it("成功桌面对话把来源、模式和 canonical runId 交给收尾回调", async () => {
+    vi.resetModules();
+    mocks.handlers.clear();
+    mocks.getSession.mockReturnValue({ id: "chat-events", mode: "chat" });
+    const { registerAgUiIpc } = await import("./agui-bridge");
+    const onFinished = vi.fn(async () => ({ sticker: null }));
+    registerAgUiIpc(async () => ({
+      options: {
+        settings: { provider: "test", baseUrl: "", model: "", apiKey: "", contextWindowTokens: 256000 },
+        messages: [],
+        timeoutMs: 1000,
+        toolSystemContent: "TOOL",
+        soulSystemBaseContent: "SOUL",
+      },
+      latestUserText: "你好",
+    }), onFinished, () => null);
+
+    const handler = mocks.handlers.get(IPC.AGUI_RUN);
+    if (!handler) throw new Error("AGUI_RUN handler was not registered");
+    const ack = await handler({
+      sender: { isDestroyed: () => false, send: () => {} },
+    }, {
+      messages: [{ role: "user", content: "你好" }],
+      sessionId: "chat-events",
+    }) as { runId: string };
+    await expect.poll(() => onFinished.mock.calls.length).toBe(1);
+
+    expect(onFinished).toHaveBeenCalledWith(
+      expect.objectContaining({ reply: "抱抱你" }),
+      "你好",
+      {
+        source: "desktop",
+        mode: "chat",
+        conversationId: "chat-events",
+        runId: ack.runId,
+      },
+    );
+  });
+
   it("routes structured Ask cards to the AG-UI run sender", async () => {
     vi.resetModules();
     mocks.handlers.clear();

--- a/src/main/agui-bridge.ts
+++ b/src/main/agui-bridge.ts
@@ -39,6 +39,7 @@ import { cancelPendingApprovalsForRun } from "./permission";
 import { approvePlan, getPlanPath, moveToReview, supplementPlan } from "./orchestrator/plan-mode";
 import { buildPlanReviewCard, buildPlanSupplementCard } from "./orchestrator/harness/plan-tools";
 import type { AskUserAnswer } from "../shared/ask-clarification";
+import type { PluginPromptMode, PluginTurnCompletedEvent } from "../plugins/types";
 /**
  * 从 RUN_FINISHED 事件中提取规范的终态结果（terminal）。
  *
@@ -124,7 +125,13 @@ export interface RunFinishedEffects {
 export type OnRunFinishedFn = (
   result: CyreneRunResult,
   latestUserText: string,
-  conversationId?: string,
+  context: {
+    source: PluginTurnCompletedEvent["source"];
+    mode: PluginPromptMode;
+    conversationId: string;
+    channel?: string;
+    runId?: string;
+  },
 ) => Promise<void | RunFinishedEffects> | void | RunFinishedEffects;
 
 /** 调用方注入：拿聊天窗口（广播副作用用，可空）。 */
@@ -692,7 +699,12 @@ export function registerAgUiIpc(
           // 这些副作用假定 run 已经成功产出回复；其他终态不能保证有可用 finalAnswer。
           if (agent.lastResult && isSuccessfulCompletion) {
             const lastResult = agent.lastResult;
-            const effects = await perf.track("on_run_finished", async () => onFinished(lastResult, latestUserText, sessionId));
+            const effects = await perf.track("on_run_finished", async () => onFinished(lastResult, latestUserText, {
+              source: "desktop",
+              mode,
+              conversationId: sessionId,
+              runId,
+            }));
             if (mode !== "code" && effects?.sticker !== undefined) {
               send({
                 type: "CUSTOM",

--- a/src/main/application/default-dependencies.ts
+++ b/src/main/application/default-dependencies.ts
@@ -54,6 +54,7 @@ import {
 import { getEmbeddingProvider, getSceneEmbeddingProvider } from "../rag/embedding";
 import { toolRegistry } from "../orchestrator/tools/registry/tool-registry";
 import { pluginPromptRegistry } from "../../plugins/prompts";
+import type { PluginManager } from "../../plugins/manager";
 import { setLive2dWindowSender } from "../orchestrator/tools/built-in-tools";
 import { registerAllTools } from "../orchestrator/tools/registry/tool-registration";
 import { LspManager } from "../lsp/manager";
@@ -154,6 +155,8 @@ async function reconcileUserMemoryIndex(): Promise<void> {
 }
 
 export function createDefaultApplicationDependencies(): ApplicationDependencies {
+  // Agent Runtime 早于插件管理器构造；通过窄闭包在运行期转发宿主事件，避免反转启动顺序。
+  let pluginManager: PluginManager | undefined;
   const readiness = createStartupReadiness();
   const activation = createWindowActivationBroker();
   const shutdown = createShutdownCoordinator({ readiness, timeoutMs: SHUTDOWN_TIMEOUT_MS });
@@ -373,6 +376,9 @@ export function createDefaultApplicationDependencies(): ApplicationDependencies 
         chatsStore,
         socialAtomStore: services.social.store,
         buildPluginPromptContext: (input) => pluginPromptRegistry.build(input),
+        publishPluginHostEvent: (event, payload) => pluginManager
+          ? pluginManager.publishHostEvent(event, payload)
+          : Promise.resolve(),
       }),
 
       createChannels: (runtime, services) => createChannelsSubsystem({
@@ -382,10 +388,13 @@ export function createDefaultApplicationDependencies(): ApplicationDependencies 
         ipc: shell.ipc,
       }),
 
-      startPlugins: (services) => startPluginRuntime({
-        llmClient: services.llm,
-        ipc: shell.ipc,
-      }),
+      startPlugins: async (services) => {
+        pluginManager = await startPluginRuntime({
+          llmClient: services.llm,
+          ipc: shell.ipc,
+        });
+        return pluginManager;
+      },
 
       createScheduler: (runtime) => createSchedulerSubsystem({
         agentRuntime: runtime,
@@ -436,7 +445,7 @@ export function createDefaultApplicationDependencies(): ApplicationDependencies 
         // AG-UI 事件流桥：渲染进程 invoke(AGUI_RUN) → CyreneAgent 跑 Agent 循环 → 事件透传
         registerAgUiIpc(
           (input) => runtime.buildOptions(input),
-          (result, latestUserText, conversationId) => runtime.onRunFinished(result, latestUserText, undefined, conversationId),
+          (result, latestUserText, context) => runtime.onRunFinished(result, latestUserText, context),
           () => reactChatWindow,
           services.proactive.proactiveConversationLifecycle,
           ipc,

--- a/src/main/channels/bootstrap.test.ts
+++ b/src/main/channels/bootstrap.test.ts
@@ -3,6 +3,11 @@
 // 不做任何初始化/启动 —— initialize / start / shutdown 必须显式调用。
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const channelMocks = vi.hoisted(() => ({
+  buildAndRunAgent: undefined as ((...args: unknown[]) => Promise<unknown>) | undefined,
+  agentError: undefined as Error | undefined,
+}));
+
 vi.mock("electron", () => ({
   app: { getPath: () => "/tmp", whenReady: async () => undefined },
   BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
@@ -17,14 +22,14 @@ vi.mock("./init", () => ({
   shutdownChannels: vi.fn(async () => undefined),
 }));
 
-// dispatcher.ts 含未提交的用户修改，测试只依赖 setter（构造期被调用但不做实事）
+// 捕获生产装配写入 dispatcher 的执行函数，以验证真实渠道完成路径。
 vi.mock("./dispatcher", () => ({
-  setDispatcherBuildAndRunAgent: vi.fn(),
+  setDispatcherBuildAndRunAgent: vi.fn((handler) => { channelMocks.buildAndRunAgent = handler; }),
   setDispatcherBroadcastChat: vi.fn(),
   setDispatcherLoadGeneralSettings: vi.fn(),
   setDispatcherLoadRecentHistory: vi.fn(),
   setDispatcherSynthesizeTts: vi.fn(),
-  formatChannelUserText: vi.fn(() => ""),
+  formatChannelUserText: vi.fn(() => "渠道问题"),
 }));
 
 // 避免拉起真实 tool registry（会级联 import RAG 等重依赖）
@@ -35,7 +40,36 @@ vi.mock("../orchestrator/tools/history-tools", () => ({
   indexConversationTurn: vi.fn(),
 }));
 vi.mock("../orchestrator/cyrene-agent", () => ({
-  CyreneAgent: class {},
+  CyreneAgent: class {
+    lastResult = { reply: "渠道回复", toolResults: [] };
+    runWithEvents() {
+      return { subscribe: ({ complete, error }: { complete: () => void; error: (err: Error) => void }) => {
+        if (channelMocks.agentError) error(channelMocks.agentError);
+        else complete();
+      } };
+    }
+  },
+}));
+vi.mock("./settings-store", () => ({
+  loadChannelsSettings: () => ({ toolSandbox: "safe" }),
+}));
+vi.mock("../settings/settings-facade", () => ({
+  loadGeneralSettings: () => ({}),
+}));
+vi.mock("../settings/model-settings", () => ({
+  loadModelSettings: () => ({}),
+  loadVisionConfig: () => undefined,
+  resolveModelSettingsProfile: () => ({ multimodal: false }),
+}));
+vi.mock("../chat/image-send-strategy", () => ({
+  decideImageSendStrategy: () => ({ mode: "none" }),
+}));
+vi.mock("./agent-input", () => ({
+  buildChannelAttachmentInputs: async () => ({ attachments: [], imageAttachments: [] }),
+}));
+vi.mock("./agent-policy", () => ({
+  resolveChannelAgentPolicy: () => ({ exposeTools: false, executionMode: "chat" }),
+  enforceChannelAgentPolicy: vi.fn(),
 }));
 
 // eslint-disable-next-line import/first
@@ -53,6 +87,7 @@ function makeChannelsDeps(): ChannelsSubsystemDeps {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  channelMocks.agentError = undefined;
 });
 
 describe("createChannelsSubsystem lifecycle", () => {
@@ -120,5 +155,69 @@ describe("createChannelsSubsystem lifecycle", () => {
     expect(initializeChannels).toHaveBeenCalledOnce();
     void startChannels;
     void shutdownChannels;
+  });
+
+  it("渠道成功回复把规范化文本和渠道上下文交给统一收尾路径", async () => {
+    const onRunFinished = vi.fn(async () => ({ sticker: null }));
+    const agentRuntime = {
+      buildOptions: vi.fn(async () => ({
+        options: { executionMode: "chat", conversationMode: "chat" },
+        latestUserText: "unused",
+      })),
+      onRunFinished,
+      buildSchedulerOptions: vi.fn(),
+    } as unknown as ChannelsSubsystemDeps["agentRuntime"];
+    createChannelsSubsystem({
+      ...makeChannelsDeps(),
+      agentRuntime,
+    });
+
+    const buildAndRunAgent = channelMocks.buildAndRunAgent;
+    if (!buildAndRunAgent) throw new Error("渠道 Agent 执行函数未注册");
+    await buildAndRunAgent({
+      channel: "telegram",
+      chatType: "direct",
+      senderId: "user-1",
+      at: new Date("2026-09-02T00:00:00Z"),
+    }, "channel-session", []);
+
+    expect(onRunFinished).toHaveBeenCalledWith(
+      { reply: "渠道回复", toolResults: [] },
+      "渠道问题",
+      {
+        source: "channel",
+        mode: "chat",
+        conversationId: "channel-session",
+        channel: "telegram",
+      },
+    );
+  });
+
+  it("渠道执行失败时不进入成功收尾路径", async () => {
+    channelMocks.agentError = new Error("渠道执行失败");
+    const onRunFinished = vi.fn(async () => ({ sticker: null }));
+    const agentRuntime = {
+      buildOptions: vi.fn(async () => ({
+        options: { executionMode: "chat", conversationMode: "chat" },
+        latestUserText: "unused",
+      })),
+      onRunFinished,
+      buildSchedulerOptions: vi.fn(),
+    } as unknown as ChannelsSubsystemDeps["agentRuntime"];
+    createChannelsSubsystem({
+      ...makeChannelsDeps(),
+      agentRuntime,
+    });
+
+    const buildAndRunAgent = channelMocks.buildAndRunAgent;
+    if (!buildAndRunAgent) throw new Error("渠道 Agent 执行函数未注册");
+    await expect(buildAndRunAgent({
+      channel: "telegram",
+      chatType: "direct",
+      senderId: "user-1",
+      at: new Date("2026-09-02T00:00:00Z"),
+    }, "channel-session", [])).rejects.toThrow("渠道执行失败");
+
+    expect(onRunFinished).not.toHaveBeenCalled();
   });
 });

--- a/src/main/channels/bootstrap.ts
+++ b/src/main/channels/bootstrap.ts
@@ -149,7 +149,12 @@ export function createChannelsSubsystem(
     });
     channelResult.text = reply;
     if (agent.lastResult) {
-      const finished = await deps.agentRuntime.onRunFinished(agent.lastResult, agentUserText, msg.channel, sessionId);
+      const finished = await deps.agentRuntime.onRunFinished(agent.lastResult, agentUserText, {
+        source: "channel",
+        mode: options.conversationMode ?? (options.executionMode === "chat" ? "chat" : "work"),
+        conversationId: sessionId,
+        channel: msg.channel,
+      });
       channelResult.sticker = finished.sticker;
     }
     void indexConversationTurn(sessionId, agentUserText, reply);

--- a/src/main/orchestrator/agent-runtime.test.ts
+++ b/src/main/orchestrator/agent-runtime.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginManager } from "../../plugins/manager";
+import { createPluginPromptRegistry } from "../../plugins/prompts";
+import type { PluginRuntime } from "../../plugins/context";
+import { createAgentRuntime, type AgentRuntimeDeps } from "./agent-runtime";
+
+const mocks = vi.hoisted(() => ({
+  onAgentRunFinished: vi.fn(),
+}));
+
+let tmp = "";
+let pluginManager: PluginManager | undefined;
+
+vi.mock("./build-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./build-options")>();
+  return { ...actual, onAgentRunFinished: mocks.onAgentRunFinished };
+});
+
+function createDeps(
+  publishPluginHostEvent: AgentRuntimeDeps["publishPluginHostEvent"],
+): AgentRuntimeDeps {
+  return {
+    runtimeStateService: {
+      getState: () => ({ status: "idle", expression: 0, updatedAt: 0 }),
+    },
+    getStickerEmbeddingIndex: () => undefined,
+    publishPluginHostEvent,
+  } as unknown as AgentRuntimeDeps;
+}
+
+describe("AgentRuntime 插件宿主事件", () => {
+  beforeEach(() => {
+    mocks.onAgentRunFinished.mockReset();
+    mocks.onAgentRunFinished.mockResolvedValue({ sticker: null });
+  });
+
+  afterEach(async () => {
+    await pluginManager?.stop();
+    pluginManager = undefined;
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    tmp = "";
+    vi.restoreAllMocks();
+  });
+
+  it("成功收尾后仅发布轮次元数据且不等待插件监听器", async () => {
+    let releaseListener!: () => void;
+    const listenerPending = new Promise<void>((resolve) => { releaseListener = resolve; });
+    const publishPluginHostEvent = vi.fn(() => listenerPending);
+    const runtime = createAgentRuntime(createDeps(publishPluginHostEvent));
+
+    await expect(runtime.onRunFinished(
+      { reply: "回复", toolResults: [] },
+      "问题",
+      {
+        source: "desktop",
+        mode: "chat",
+        conversationId: "conversation-1",
+        runId: "run-1",
+      },
+    )).resolves.toEqual({ sticker: null });
+
+    expect(publishPluginHostEvent).toHaveBeenCalledWith("turn:completed", {
+      source: "desktop",
+      mode: "chat",
+      conversationId: "conversation-1",
+      runId: "run-1",
+    });
+    releaseListener();
+  });
+
+  it("成功收尾后通过真实 PluginManager 和 EventBus 到达插件监听器", async () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-turn-event-"));
+    const pluginDir = path.join(tmp, "listener");
+    const marker = path.join(tmp, "received.json");
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(path.join(pluginDir, "manifest.json"), JSON.stringify({
+      apiVersion: 1,
+      id: "listener",
+      name: "listener",
+      version: "1.0.0",
+      description: "test listener",
+      author: "test",
+      entry: "index.cjs",
+      defaultEnabled: true,
+    }), "utf8");
+    writeFileSync(path.join(pluginDir, "index.cjs"), `
+      const fs = require("node:fs");
+      module.exports = { register(ctx) {
+        ctx.events.on("host:turn:completed", (payload) => {
+          fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify(payload));
+        });
+      } };
+    `, "utf8");
+
+    const runtime: PluginRuntime = {
+      toolRegistry: { register: () => {}, unregister: () => true },
+      channelManager: { has: () => false, register: () => {}, unregister: async () => true, startOne: async () => {} },
+      registerIpc: () => {},
+      unregisterIpc: () => {},
+      promptRegistry: createPluginPromptRegistry(),
+    };
+    pluginManager = new PluginManager({
+      scanRoots: [{ path: tmp, source: "builtin" }],
+      storageRoot: path.join(tmp, "storage"),
+      runtime,
+      loadEnabledMap: () => ({}),
+      saveEnabledMap: () => {},
+    });
+    await pluginManager.start();
+
+    const agentRuntime = createAgentRuntime(createDeps(
+      (event, payload) => pluginManager!.publishHostEvent(event, payload),
+    ));
+    await agentRuntime.onRunFinished(
+      { reply: "真实回复", toolResults: [] },
+      "真实问题",
+      {
+        source: "desktop",
+        mode: "chat",
+        conversationId: "conversation-real",
+        runId: "run-real",
+      },
+    );
+
+    await expect.poll(() => existsSync(marker)).toBe(true);
+    expect(JSON.parse(readFileSync(marker, "utf8"))).toEqual({
+      source: "desktop",
+      mode: "chat",
+      conversationId: "conversation-real",
+      runId: "run-real",
+    });
+  });
+
+  it("宿主收尾失败时不发布成功完成事件", async () => {
+    mocks.onAgentRunFinished.mockRejectedValueOnce(new Error("收尾失败"));
+    const publishPluginHostEvent = vi.fn(async () => {});
+    const runtime = createAgentRuntime(createDeps(publishPluginHostEvent));
+
+    await expect(runtime.onRunFinished(
+      { reply: "不会发布", toolResults: [] },
+      "问题",
+      { source: "desktop", mode: "chat", conversationId: "conversation-failed" },
+    )).rejects.toThrow("收尾失败");
+    expect(publishPluginHostEvent).not.toHaveBeenCalled();
+  });
+
+  it("插件事件发布失败不改变宿主收尾结果", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const runtime = createAgentRuntime(createDeps(async () => {
+      throw new Error("监听器失败");
+    }));
+
+    await expect(runtime.onRunFinished(
+      { reply: "正常回复", toolResults: [] },
+      "问题",
+      { source: "desktop", mode: "chat", conversationId: "conversation-listener-failed" },
+    )).resolves.toEqual({ sticker: null });
+    await expect.poll(() => warn.mock.calls.length).toBe(1);
+  });
+});

--- a/src/main/orchestrator/agent-runtime.test.ts
+++ b/src/main/orchestrator/agent-runtime.test.ts
@@ -71,6 +71,30 @@ describe("AgentRuntime 插件宿主事件", () => {
     releaseListener();
   });
 
+  it.each(["timeout", "cancelled", "runtime_error"] as const)(
+    "非成功终态 %s 不发布轮次完成事件",
+    async (status) => {
+      const publishPluginHostEvent = vi.fn(async () => {});
+      const runtime = createAgentRuntime(createDeps(publishPluginHostEvent));
+
+      await runtime.onRunFinished(
+        {
+          reply: "未成功结束的部分回复",
+          toolResults: [],
+          terminal: {
+            status,
+            reason: "未成功结束",
+            externalEffectsMayContinue: true,
+          },
+        },
+        "问题",
+        { source: "desktop", mode: "chat", conversationId: "conversation-not-completed" },
+      );
+
+      expect(publishPluginHostEvent).not.toHaveBeenCalled();
+    },
+  );
+
   it("成功收尾后通过真实 PluginManager 和 EventBus 到达插件监听器", async () => {
     tmp = mkdtempSync(path.join(os.tmpdir(), "cyrene-turn-event-"));
     const pluginDir = path.join(tmp, "listener");

--- a/src/main/orchestrator/agent-runtime.ts
+++ b/src/main/orchestrator/agent-runtime.ts
@@ -275,6 +275,11 @@ export function createAgentRuntime(rawDeps: AgentRuntimeDeps): AgentRuntime {
         context.channel as ChannelId | undefined,
         context.conversationId,
       );
+      // 调用方应只在成功终态进入收尾；此处再守住插件事件契约，避免未来新增入口误报完成。
+      const terminalStatus = result.terminal?.status;
+      if (terminalStatus !== undefined && terminalStatus !== "success") {
+        return effects;
+      }
       const payload: PluginTurnCompletedEvent = {
         source: context.source,
         mode: context.mode,

--- a/src/main/orchestrator/agent-runtime.ts
+++ b/src/main/orchestrator/agent-runtime.ts
@@ -50,7 +50,11 @@ import { resolveRunCapabilities } from "./run-capabilities";
 import { loadStickerSettings } from "./sticker-settings";
 import type { RuntimeStateService } from "./runtime-state-service";
 import type { LlmClient } from "../services/llm/llm-client";
-import type { PluginPromptBuildInput } from "../../plugins/types";
+import type {
+  PluginTurnCompletedEvent,
+  PluginPromptBuildInput,
+  PluginPromptMode,
+} from "../../plugins/types";
 
 type EnqueueLLMTask = <T>(
   label: string,
@@ -80,13 +84,22 @@ export interface AgentRuntimeDeps {
   chatsStore: { getWorkspaceBinding: (conversationId: string) => { workspaceRoot: string; displayName: string; boundAt: number } | undefined };
   socialAtomStore: { listActive: (conversationId: string, now: number) => SocialAtom[] };
   buildPluginPromptContext: (input: PluginPromptBuildInput) => Promise<string>;
+  publishPluginHostEvent: <T>(event: string, payload: T) => Promise<void>;
 }
 
 type SchedulerRunOptions = Omit<CyreneRunOptions, "toolSystemContent" | "soulSystemBaseContent">;
 
+export interface AgentRunFinishedContext {
+  source: PluginTurnCompletedEvent["source"];
+  mode: PluginPromptMode;
+  conversationId: string;
+  channel?: string;
+  runId?: string;
+}
+
 export interface AgentRuntime {
   buildOptions(input: AguiRunInput): Promise<{ options: CyreneRunOptions; latestUserText: string }>;
-  onRunFinished(result: CyreneRunResult, latestUserText: string, channel?: ChannelId, conversationId?: string): Promise<{ sticker: string | null }>;
+  onRunFinished(result: CyreneRunResult, latestUserText: string, context: AgentRunFinishedContext): Promise<{ sticker: string | null }>;
   buildSchedulerOptions(task: ScheduledTask): Promise<SchedulerRunOptions>;
 }
 
@@ -253,9 +266,27 @@ export function createAgentRuntime(rawDeps: AgentRuntimeDeps): AgentRuntime {
       return buildAgentRunOptions(input, buildOptionsDeps);
     },
 
-    onRunFinished: async (result, latestUserText, channel, conversationId) => {
+    onRunFinished: async (result, latestUserText, context) => {
       const onRunFinishedDeps = buildOnRunFinishedDeps();
-      return onAgentRunFinished(result, latestUserText, onRunFinishedDeps, channel, conversationId);
+      const effects = await onAgentRunFinished(
+        result,
+        latestUserText,
+        onRunFinishedDeps,
+        context.channel as ChannelId | undefined,
+        context.conversationId,
+      );
+      const payload: PluginTurnCompletedEvent = {
+        source: context.source,
+        mode: context.mode,
+        conversationId: context.conversationId,
+        ...(context.channel ? { channel: context.channel } : {}),
+        ...(context.runId ? { runId: context.runId } : {}),
+      };
+      // 插件监听器属于旁路扩展：不等待它们，避免第三方插件延迟主回复的终态事件。
+      void rawDeps.publishPluginHostEvent("turn:completed", payload).catch((error) => {
+        console.warn("[plugins] 发布对话轮次完成事件失败", error);
+      });
+      return effects;
     },
 
     buildSchedulerOptions: async (task) => {

--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -173,6 +173,15 @@ export interface PluginEvents {
   emit<T = unknown>(event: string, payload: T): Promise<void>;
 }
 
+/** host:turn:completed 的公开 payload；首版只暴露稳定元数据，不包含对话原文。 */
+export interface PluginTurnCompletedEvent {
+  source: "desktop" | "channel";
+  mode: PluginPromptMode;
+  conversationId: string;
+  channel?: string;
+  runId?: string;
+}
+
 export interface PluginDeps {
   /** Read-only channel discovery. Registration must use PluginContext methods. */
   channels?: { has(id: string): boolean };


### PR DESCRIPTION
## 相关 Issue

Related: #58

> 上游维护者已在 #58 确认该插件 API 的能力边界；本次更新已按确认结论收窄 payload、调整事件命名并补齐失败路径测试。

## 变更说明

#53 已提供带命名空间的事件总线，#55 已提供每轮动态提示词 Provider。统计等通用插件还需要在不改动主对话实现的情况下观察“成功完成的一轮对话”，因此本 PR 补充一个最小的宿主事件。

- 新增 `host:turn:completed`：
  - 仅在桌面或外部渠道的一轮对话以 `success` 终态完成，并执行现有 `onRunFinished` 收尾后发布；
  - 首版 payload 仅包含 `source`、`mode`、`conversationId` 和可选 `channel` / `runId`；
  - 不广播 `userText` / `assistantText`，也不暴露完整历史、模型配置、工具内部状态、checkpoint、压缩或任务委派对象。
- 桌面 AG-UI 与 Channels 共用同一事件契约。
- 发布侧使用 `void`，不等待顺序执行的插件监听器，避免插件延迟主回复终态。
- 取消、超时、运行错误或宿主收尾失败不会发布成功完成事件。
- 插件监听器失败不会改变既有宿主收尾结果。
- 增加公开 TypeScript 类型、中文注释和开发文档。
- 本 PR 不包含具体插件实现，也不修改 Harness、transcript、Provider Adapter、权限、压缩、恢复或任务系统。
- 已同步当前上游 `master`，并清理由并行文档更新造成的重复事件 API 表格项。

## 测试

1. 定向测试：
   `npm.cmd test -- --run --maxWorkers=1 src/main/orchestrator/agent-runtime.test.ts src/main/agui-bridge.test.ts src/main/channels/bootstrap.test.ts src/plugins/events.test.ts src/plugins/context.test.ts src/plugins/manager.test.ts`
   - 6 个测试文件、90 项测试全部通过。
2. 完整构建：
   `npm.cmd run build`
   - main、preload、CLI、renderer 全部通过。
3. 全量回归：
   `npm.cmd test -- --run --maxWorkers=1`
   - 388 个测试文件通过、3 个失败；3004/3013 项测试通过；
   - 其余 9 项均为受限测试环境中的既有失败：6 项 `os.userInfo()` / `uv_os_get_passwd ENOMEM`，2 项尝试写入固定路径 `C:\cyrene-test-user-data`，1 项尝试写入固定路径 `C:\cyrene-characterization`；
   - 本 PR 新增及相关测试均通过。
4. 实际跨层链路：
   - 桌面 AG-UI 成功路径验证 `source`、`mode`、`conversationId` 和 canonical `runId` 进入统一收尾；
   - Channels 成功路径验证渠道上下文进入统一收尾；
   - 真实加载测试插件，并验证 `AgentRuntime → PluginManager → Context → EventBus → 插件监听器` 最终收到仅含元数据的 payload；
   - 验证宿主收尾失败不发布事件，慢监听器与监听器失败不阻塞或改变主回复结果；
   - 桌面取消与 `runtime_error` 路径、渠道错误路径均验证不会进入成功收尾。
5. `git diff --check origin/master...HEAD`
   - 通过。

## 注释语言

* [x] 新增注释尽量使用中文，或保持所在模块原有风格

## Checklist（检查清单）

* [x] 已确认代码可以正常运行
* [x] 已检查改动范围，没有夹带无关文件、重构或功能
* [x] 新功能或 Bug 修复已进行必要测试
* [x] 如果改动跨越多个模块，已验证实际运行时的完整链路，而不只是局部函数或 Adapter
* [x] 如有需要，已补充相关说明
* [x] 改动保持单一职责，没有顺手重构或扩展与本次 PR 目的无关的模块
* [x] 如果涉及核心模块或插件 API，已通过 #58 与维护者讨论并确认方向
* [x] 如果新增了进程、租约、缓存、临时数据、AbortSignal 等具有生命周期的资源，已考虑正常结束、失败、中止和退出时的清理（本 PR 未新增此类资源）
* [x] 已考虑对现有功能的回归影响，而不仅是新功能自身是否能够运行
* [x] 已考虑长期维护成本，避免让多个核心模块为了单一功能增加长期存在的特殊逻辑或耦合