### PR TITLE
fix: 阻止渠道超时进入成功收尾

### DIFF
--- a/src/main/channels/bootstrap.test.ts
+++ b/src/main/channels/bootstrap.test.ts
@@ -3,6 +3,10 @@
 // 不做任何初始化/启动 —— initialize / start / shutdown 必须显式调用。
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const channelMocks = vi.hoisted(() => ({
+  buildAndRunAgent: undefined as ((...args: unknown[]) => Promise<unknown>) | undefined,
+}));
+
 vi.mock("electron", () => ({
   app: { getPath: () => "/tmp", whenReady: async () => undefined },
   BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
@@ -17,14 +21,14 @@ vi.mock("./init", () => ({
   shutdownChannels: vi.fn(async () => undefined),
 }));
 
-// dispatcher.ts 含未提交的用户修改，测试只依赖 setter（构造期被调用但不做实事）
+// 捕获生产装配写入 dispatcher 的执行函数，用于验证渠道终态边界。
 vi.mock("./dispatcher", () => ({
-  setDispatcherBuildAndRunAgent: vi.fn(),
+  setDispatcherBuildAndRunAgent: vi.fn((handler) => { channelMocks.buildAndRunAgent = handler; }),
   setDispatcherBroadcastChat: vi.fn(),
   setDispatcherLoadGeneralSettings: vi.fn(),
   setDispatcherLoadRecentHistory: vi.fn(),
   setDispatcherSynthesizeTts: vi.fn(),
-  formatChannelUserText: vi.fn(() => ""),
+  formatChannelUserText: vi.fn(() => "渠道问题"),
 }));
 
 // 避免拉起真实 tool registry（会级联 import RAG 等重依赖）
@@ -35,7 +39,46 @@ vi.mock("../orchestrator/tools/history-tools", () => ({
   indexConversationTurn: vi.fn(),
 }));
 vi.mock("../orchestrator/cyrene-agent", () => ({
-  CyreneAgent: class {},
+  CyreneAgent: class {
+    lastResult = {
+      reply: "超时前的部分回复",
+      toolResults: [],
+      terminal: {
+        status: "timeout",
+        reason: "timeout",
+        externalEffectsMayContinue: true,
+      },
+    };
+
+    runWithEvents() {
+      return {
+        subscribe: ({ complete }: { complete: () => void }) => {
+          complete();
+        },
+      };
+    }
+  },
+}));
+vi.mock("./settings-store", () => ({
+  loadChannelsSettings: () => ({ toolSandbox: "safe" }),
+}));
+vi.mock("../settings/settings-facade", () => ({
+  loadGeneralSettings: () => ({}),
+}));
+vi.mock("../settings/model-settings", () => ({
+  loadModelSettings: () => ({}),
+  loadVisionConfig: () => undefined,
+  resolveModelSettingsProfile: () => ({ multimodal: false }),
+}));
+vi.mock("../chat/image-send-strategy", () => ({
+  decideImageSendStrategy: () => ({ mode: "none" }),
+}));
+vi.mock("./agent-input", () => ({
+  buildChannelAttachmentInputs: async () => ({ attachments: [], imageAttachments: [] }),
+}));
+vi.mock("./agent-policy", () => ({
+  resolveChannelAgentPolicy: () => ({ exposeTools: false, executionMode: "chat" }),
+  enforceChannelAgentPolicy: vi.fn(),
 }));
 
 // eslint-disable-next-line import/first
@@ -120,5 +163,33 @@ describe("createChannelsSubsystem lifecycle", () => {
     expect(initializeChannels).toHaveBeenCalledOnce();
     void startChannels;
     void shutdownChannels;
+  });
+
+  it("渠道超时终态不进入成功收尾", async () => {
+    const onRunFinished = vi.fn(async () => ({ sticker: null }));
+    const agentRuntime = {
+      buildOptions: vi.fn(async () => ({
+        options: { executionMode: "chat", conversationMode: "chat" },
+        latestUserText: "unused",
+      })),
+      onRunFinished,
+      buildSchedulerOptions: vi.fn(),
+    } as unknown as ChannelsSubsystemDeps["agentRuntime"];
+    createChannelsSubsystem({
+      ...makeChannelsDeps(),
+      agentRuntime,
+    });
+
+    const buildAndRunAgent = channelMocks.buildAndRunAgent;
+    if (!buildAndRunAgent) throw new Error("渠道 Agent 执行函数未注册");
+    const result = await buildAndRunAgent({
+      channel: "telegram",
+      chatType: "direct",
+      senderId: "user-1",
+      at: new Date("2026-09-02T00:00:00Z"),
+    }, "channel-session", []) as { text: string };
+
+    expect(result.text).toBe("超时前的部分回复");
+    expect(onRunFinished).not.toHaveBeenCalled();
   });
 });

--- a/src/main/channels/bootstrap.ts
+++ b/src/main/channels/bootstrap.ts
@@ -148,7 +148,9 @@ export function createChannelsSubsystem(
       });
     });
     channelResult.text = reply;
-    if (agent.lastResult) {
+    // Observable 在超时终态下也会正常 complete；只有成功终态才能进入记忆、表情等成功收尾。
+    const terminalStatus = agent.lastResult?.terminal?.status;
+    if (agent.lastResult && (terminalStatus === undefined || terminalStatus === "success")) {
       const finished = await deps.agentRuntime.onRunFinished(agent.lastResult, agentUserText, msg.channel, sessionId);
       channelResult.sticker = finished.sticker;
     }


### PR DESCRIPTION
## 相关 PR

Related: #56

本修复处理评审 #56 时发现的宿主侧旧缺口。合入后，#56 仍需同步最新 `master`，并保留“非成功终态不发布完成事件”的契约测试。

## 变更说明

- 渠道 Agent 在 `timeout` 等非成功终态下不再进入 `onRunFinished` 成功收尾；
- 保留缺少 `terminal` 字段时按成功处理的兼容行为；
- 新增真实渠道装配回归测试，验证超时仍可返回已有回复，但不会触发成功收尾。

## 测试

1. 相关测试：`npm.cmd test -- --run --maxWorkers=1 src/main/channels src/main/orchestrator/cyrene-agent.test.ts src/main/agui-bridge.test.ts`
   - 28 个测试文件、223 项测试全部通过。
2. 完整构建：`npm.cmd run build`
   - main、preload、CLI、renderer 全部通过。
3. 全量回归：`npm.cmd test -- --run --maxWorkers=1`
   - 390 个测试文件、3007 项测试全部通过。
4. `git diff --check`
   - 通过。

## 注释语言

- [x] 新增注释使用中文

## Checklist（检查清单）

- [x] 已确认代码可以正常运行
- [x] 已检查改动范围，没有夹带无关文件、重构或功能
- [x] Bug 修复已进行必要测试
- [x] 已验证实际渠道运行链路，而不只是局部函数
- [x] 已考虑对现有成功路径和旧版终态字段的兼容
- [x] 改动保持单一职责