### PR TITLE
fix(reasoning): 厂商/模型家族错配时按模型名跨家族推断推理能力

### DIFF
--- a/src/renderer/react/features/chat/components/ReasoningControl.css
+++ b/src/renderer/react/features/chat/components/ReasoningControl.css
@@ -46,16 +46,21 @@
 
 .cy-reasoning-popover .ant-segmented-item {
   min-width: 44px;
-  color: #5d5d5d;
+  color: var(--cy-text-muted, #5d5d5d);
   font: 500 12px/28px var(--rb-font-sans, sans-serif);
 }
 
-.cy-reasoning-popover .ant-segmented-item-selected {
-  color: #fff;
+/* antd v6 的滑块是 .ant-segmented-thumb 元素（v4 时代的 item::after 写法已失效，
+   默认白色块会盖住选中文字）。改为半透明强调色高亮 + 选中文字用强调色，
+   跟随昔涟主题变量（--cy-accent），变量缺失时回退默认粉。 */
+.cy-reasoning-popover .ant-segmented-thumb {
+  border-radius: 8px;
+  background: rgba(255, 91, 138, 0.22);
+  background: color-mix(in srgb, var(--cy-accent, #FF5B8A) 22%, transparent);
+  box-shadow: none;
 }
 
-.cy-reasoning-popover .ant-segmented-item-selected::after {
-  border-radius: 8px;
-  background: var(--cy-accent);
-  box-shadow: none;
+.cy-reasoning-popover .ant-segmented-item-selected {
+  color: var(--cy-accent, #FF5B8A);
+  font-weight: 600;
 }

--- a/src/shared/reasoning.test.ts
+++ b/src/shared/reasoning.test.ts
@@ -581,3 +581,45 @@ describe("foldReasoning — 持久化折叠（用户第三轮修订 #4）", () =
     expect(foldReasoning(topLevel, existing, true)).toEqual({ mode: "on", effort: "low" });
   });
 });
+
+describe("resolveReasoningCapability — 厂商/模型家族错配时按模型名推断", () => {
+  test("I1 自定义端点托管 glm-5.3-flash（方舟 coding plan 场景）→ 命中 glm-5.3 强制思考规则", () => {
+    const cap = resolveReasoningCapability("unknown", "glm-5.3-flash");
+    expect(cap.control).toBe("toggle-effort");
+    expect(cap.requestStyle).toBe("thinking-type");
+    expect(cap.supportedEfforts).toEqual(["low", "high", "max"]);
+    expect(cap.supportsDisable).toBe(false);
+    expect(cap.autoEffort).toBe("high");
+  });
+
+  test("I2 自定义端点托管 glm-5.3 → 同一规则", () => {
+    const cap = resolveReasoningCapability("unknown", "glm-5.3");
+    expect(cap.control).toBe("toggle-effort");
+  });
+
+  test("I3 托管 doubao-seed 系列 → 命中豆包 toggle 规则", () => {
+    const cap = resolveReasoningCapability("unknown", "doubao-seed-2-1-pro-260628");
+    expect(cap.control).toBe("toggle");
+    expect(cap.supportsDisable).toBe(true);
+  });
+
+  test("I4 未识别模型名 → 保持 UNKNOWN 兜底（control=none）", () => {
+    const cap = resolveReasoningCapability("unknown", "some-homemade-endpoint-model");
+    expect(cap.control).toBe("none");
+    expect(cap.requestStyle).toBe("none");
+  });
+
+  test("I5 厂商家族无真实规则 + 模型名也未识别 → 仍 UNKNOWN（不误匹配）", () => {
+    const cap = resolveReasoningCapability("glm", "not-a-real-glm-model");
+    expect(cap.control).toBe("none");
+    expect(cap.requestStyle).toBe("none");
+  });
+
+  test("I6 家族错配回归：豆包档案跑 glm-5.3-flash（方舟 coding plan 真实场景）→ 按模型名命中 glm 规则", () => {
+    const cap = resolveReasoningCapability("doubao", "glm-5.3-flash");
+    expect(cap.control).toBe("toggle-effort");
+    expect(cap.requestStyle).toBe("thinking-type");
+    expect(cap.supportedEfforts).toEqual(["low", "high", "max"]);
+    expect(cap.supportsDisable).toBe(false);
+  });
+});

--- a/src/shared/reasoning.ts
+++ b/src/shared/reasoning.ts
@@ -193,9 +193,10 @@ export const MODEL_REASONING_RULES: readonly ModelReasoningRule[] = [
   // ── glm（智谱）──
   // 精确型号在前；glm-5 基础型号放在精确型号之后（兜底更宽的 glm-5 系列）。
   // GLM-5.3 / GLM-5.3-Flash：强制思考模型（thinking.type=disabled 服务端报错，
-  // 官方文档 2026-08-26；z.ai 文档明确 FLASH 同为强制思考）。
-  // 支持 low/high/max 三档 effort。auto 档显式映射 high —— 服务端默认 max，
-  // auto 不发字段 ≡ max，多步任务思考爆炸。
+  // 官方文档 2026-08-26；z.ai 文档明确 FLASH 同为强制思考；
+  // 2026-09-06 实测方舟托管端点 api/coding/v3 同样返回 400，强制思考跨端点成立）。
+  // 支持 low/high/max 三档 effort（方舟端点 reasoning_effort 实测可用）。
+  // auto 档显式映射 high —— 服务端默认 max，auto 不发字段 ≡ max，多步任务思考爆炸。
   { providerId: "glm", modelPattern: /^glm-5\.3/i, capability: {
     control: "toggle-effort",
     supportedEfforts: ["low", "high", "max"],
@@ -340,13 +341,27 @@ export const MODEL_REASONING_RULES: readonly ModelReasoningRule[] = [
 /**
  * 按 (providerId, model) 解析推理 capability。
  * 未命中任何规则时返回兜底 { control: "none", requestStyle: "none", supportsDisable: false }。
+ *
+ * 模型名推断兜底：厂商家族与模型家族不一致时（自定义端点 / 托管场景，如方舟
+ * coding plan 上跑 glm-5.3-flash，档案厂商登记为「豆包（火山方舟）」），第一轮
+ * 同厂商匹配只能命中表尾通配兜底。此时按模型名跨家族找回真正的推理规则，
+ * 使推理控制在托管端点上同样可用。各家族表尾的通配兜底规则均引用同一个
+ * UNKNOWN_CAPABILITY 常量，用恒等判断跳过即可，不会误匹配。
  */
 export function resolveReasoningCapability(
   providerId: string,
   model: string,
 ): ReasoningCapability {
+  // 第一轮：同厂商精确规则（表尾通配兜底不算命中，留给第二轮）
   for (const rule of MODEL_REASONING_RULES) {
-    if (rule.providerId === providerId && rule.modelPattern.test(model)) {
+    if (rule.providerId === providerId && rule.modelPattern.test(model)
+        && rule.capability !== UNKNOWN_CAPABILITY) {
+      return rule.capability;
+    }
+  }
+  // 第二轮：模型名跨家族推断（第一轮未出真实规则时兜底）
+  for (const rule of MODEL_REASONING_RULES) {
+    if (rule.modelPattern.test(model) && rule.capability !== UNKNOWN_CAPABILITY) {
       return rule.capability;
     }
   }


### PR DESCRIPTION
## 一句话总结

在「豆包（火山方舟）」这类托管端点上跑别的家族模型（比如 GLM）时，思考强度下拉会被整体禁用、请求里也不带思考控制字段。原因是能力匹配只查「档案厂商」自己的规则，本 PR 加了一步「按模型名跨厂商找回规则」的兜底，让托管端点上的知名模型也能正常调档。顺带修了推理面板滑块在 antd v6 下白块盖字的问题。

## 用户视角的现象（复现步骤）

1. 模型档案：厂商选「豆包（火山方舟）」，Base URL 填方舟 coding plan（`https://ark.cn-beijing.volces.com/api/coding/v3`），模型填 `glm-5.3-flash`
2. 聊天窗口点「thinking」按钮 → 下拉整体灰置，只有「跟随模型」
3. 同时请求体里不带任何 thinking 字段，`auto` 档实际吃的是服务端默认档——GLM-5.3 是 max，多步任务思考时间爆炸

原因链：档案厂商「豆包（火山方舟）」能正常识别成 doubao，但 doubao 的规则只登记了 `doubao-seed-*`，`glm-5.3-flash` 一条都匹配不上，最后落在每家规则表末尾的「任意模型」兜底行上（这条的 capability 就是 UNKNOWN），UI 于是按「未配置」渲染。规则表里明明有 glm-5.3 的规则（low/high/max 三档），只是解析流程轮不到它出场。

## 修法（`resolveReasoningCapability`，src/shared/reasoning.ts）

原来只查一轮「同厂商规则」，现在改成两轮：

1. **第一轮**：查档案厂商自己的规则——但每家末尾那条「任意模型」兜底不算数。它们都指向同一个 `UNKNOWN_CAPABILITY` 常量，用恒等判断就能排除，不影响其它匹配
2. **第二轮（新增兜底）**：第一轮没找到真规则时，拿模型名去所有厂商的规则里找。`glm-5.3-flash` 就这样找回 glm 家族的规则
3. 还找不到才返回 UNKNOWN

效果：

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 豆包档案 + glm-5.3-flash（方舟 coding plan） | 下拉禁用，不带思考字段 | 出「跟随模型 / 低 / 高 / 最强」，auto 显式映射 high |
| 厂商与模型同家族 | 正常 | 不变（第一轮直接命中，行为一致） |
| 未登记的模型 | UNKNOWN | 仍是 UNKNOWN，不会误发字段 |

## 实测（方舟 coding plan + glm-5.3-flash，真实 key 发最小请求验证）

| 探针 | 结果 | 结论 |
| --- | --- | --- |
| `thinking.type=disabled` | HTTP 400 `not supported by this model` | 强制思考是模型/服务端行为，跨端点成立——glm-5.3 规则的 `supportsDisable: false` 不用改，实测结论已补进注释 |
| `reasoning_effort=low` | 200 OK | 方舟接受 effort 字段 |
| `thinking.type=enabled` + `reasoning_effort=high` | 200 OK | 现行 glm 规则发出的字段组合与方舟端点完全兼容 |

## 附带修复：推理面板滑块白块盖字（第 2 个 commit）

ReasoningControl.css 里滑块样式用的是 antd v4 时代的 `.ant-segmented-item-selected::after` 选择器。antd v6 的滑块已经是 `.ant-segmented-thumb` 元素，所以这条规则一直没生效：滑块保持 antd 默认白色，选中文字又是白色——白底白字，什么都看不见。

改为对 `.ant-segmented-thumb` 加半透明强调色高亮，选中文字用 `--cy-accent`（变量缺失时回退默认粉），未选中文字走 `--cy-text-muted`。

## 测试

- `src/shared/reasoning.test.ts` 新增 6 例：unknown 推断、doubao × glm-5.3-flash 家族错配回归（真实场景）、未识别模型不误匹配等；本文件 85/85 通过
- 全量 `vitest run`：**438 个测试文件 / 3629 个用例全部通过**

改动范围：2 个源文件 + 1 个测试文件。同厂商能命中的所有场景行为不变，只有原先「错配落到 UNKNOWN」的路径多了一次按模型名的找回机会。
