### PR TITLE
渠道消息直接显示在绑定的桌面对话中

### DIFF
--- a/src/main/channels/bootstrap.test.ts
+++ b/src/main/channels/bootstrap.test.ts
@@ -9,6 +9,9 @@ const channelMocks = vi.hoisted(() => ({
   flush: vi.fn(),
   listSessions: vi.fn(),
   getSession: vi.fn(),
+  appendMessage: vi.fn(),
+  loadBoundConversationHistory: undefined as ((conversationId: string, limit: number) => Promise<Array<{ role: "user" | "assistant"; content: string }>>) | undefined,
+  appendBoundConversationMessage: undefined as ((conversationId: string, role: "user" | "assistant", content: string, metadata: { channel: "wechat" | "feishu" | "qq" | "qqbot"; senderName?: string; modelContext?: string }) => void) | undefined,
   buildAndRunAgent: undefined as ((...args: unknown[]) => Promise<unknown>) | undefined,
   agentError: undefined as Error | undefined,
   agentResult: { reply: "渠道回复", toolResults: [] } as {
@@ -44,8 +47,8 @@ vi.mock("./dispatcher", () => ({
   setDispatcherLoadRecentHistory: vi.fn(),
   setDispatcherObserveExternalChat: vi.fn(),
   setDispatcherResolveBoundConversation: vi.fn((handler) => { channelMocks.resolveBoundConversation = handler; }),
-  setDispatcherLoadBoundConversationHistory: vi.fn(),
-  setDispatcherAppendBoundConversationMessage: vi.fn(),
+  setDispatcherLoadBoundConversationHistory: vi.fn((handler) => { channelMocks.loadBoundConversationHistory = handler; }),
+  setDispatcherAppendBoundConversationMessage: vi.fn((handler) => { channelMocks.appendBoundConversationMessage = handler; }),
   setDispatcherSynthesizeTts: vi.fn(),
   formatChannelUserText: vi.fn(() => "渠道问题"),
 }));
@@ -56,7 +59,7 @@ vi.mock("./conversation-binding-store", () => ({
 vi.mock("../chats/chats-store", () => ({
   listSessions: channelMocks.listSessions,
   getSession: channelMocks.getSession,
-  appendMessage: vi.fn(),
+  appendMessage: channelMocks.appendMessage,
 }));
 
 // 避免拉起真实 tool registry（会级联 import RAG 等重依赖）
@@ -138,9 +141,46 @@ beforeEach(() => {
   vi.clearAllMocks();
   channelMocks.agentError = undefined;
   channelMocks.agentResult = { reply: "渠道回复", toolResults: [] };
+  channelMocks.loadBoundConversationHistory = undefined;
+  channelMocks.appendBoundConversationMessage = undefined;
 });
 
 describe("createChannelsSubsystem lifecycle", () => {
+  it("loads model context for new mirrored messages and keeps old messages compatible", async () => {
+    channelMocks.getSession.mockReturnValue({
+      messages: [
+        { role: "user", content: "旧消息" },
+        { role: "user", content: "大家好", modelContext: "[QQ群发送者：伙伴]\n大家好" },
+        { role: "model", content: "你好" },
+      ],
+    });
+    createChannelsSubsystem(makeChannelsDeps());
+
+    await expect(channelMocks.loadBoundConversationHistory?.("desktop-1", 10)).resolves.toEqual([
+      { role: "user", content: "旧消息" },
+      { role: "user", content: "[QQ群发送者：伙伴]\n大家好" },
+      { role: "assistant", content: "你好" },
+    ]);
+  });
+
+  it("persists clean bubble text together with channel and model-context metadata", () => {
+    channelMocks.appendMessage.mockReturnValue({ id: "desktop-1" });
+    createChannelsSubsystem(makeChannelsDeps());
+
+    channelMocks.appendBoundConversationMessage?.("desktop-1", "user", "大家好", {
+      channel: "qq",
+      senderName: "伙伴",
+      modelContext: "[QQ群发送者：伙伴]\n大家好",
+    });
+
+    expect(channelMocks.appendMessage).toHaveBeenCalledWith("desktop-1", expect.objectContaining({
+      role: "user",
+      content: "大家好",
+      modelContext: "[QQ群发送者：伙伴]\n大家好",
+      channelSource: { channel: "qq", senderName: "伙伴" },
+    }));
+  });
+
   it("resolves bindings from metadata without reading the full conversation", () => {
     channelMocks.bindingResolve.mockReturnValue("desktop-1");
     channelMocks.listSessions.mockReturnValue([{ id: "desktop-1" }]);

--- a/src/main/channels/bootstrap.ts
+++ b/src/main/channels/bootstrap.ts
@@ -101,16 +101,21 @@ export function createChannelsSubsystem(
       .slice(-limit)
       .map((message) => ({
         role: message.role === "model" ? "assistant" as const : "user" as const,
-        content: message.content,
+        content: message.modelContext?.trim() || message.content,
       }));
   });
 
-  setDispatcherAppendBoundConversationMessage((conversationId, role, content) => {
+  setDispatcherAppendBoundConversationMessage((conversationId, role, content, metadata) => {
     const session = appendMessage(conversationId, {
       id: randomUUID(),
       role: role === "assistant" ? "model" : "user",
       content,
       at: Date.now(),
+      modelContext: metadata.modelContext,
+      channelSource: {
+        channel: metadata.channel,
+        senderName: metadata.senderName,
+      },
     });
     if (!session) throw new Error("Bound conversation no longer exists");
     const win = deps.getReactChatWindow();

--- a/src/main/channels/dispatcher.test.ts
+++ b/src/main/channels/dispatcher.test.ts
@@ -132,9 +132,43 @@ describe("channels/dispatcher", () => {
     expect(result?.targetId).toBe("chat-1");
     expect(loadRecentChannelHistory).not.toHaveBeenCalled();
     expect(loadBoundConversationHistory).toHaveBeenCalledWith("conversation-7", 16);
-    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(1, "conversation-7", "user", "你好");
-    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(2, "conversation-7", "assistant", "共享回复");
+    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(1, "conversation-7", "user", "你好", {
+      channel,
+      senderName: "测试用户",
+      modelContext: undefined,
+    });
+    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(2, "conversation-7", "assistant", "共享回复", {
+      channel,
+      senderName: "测试用户",
+      modelContext: undefined,
+    });
     expect(buildAndRunAgent).toHaveBeenCalledOnce();
+  });
+
+  it("keeps QQ group identity in model context without putting it in the visible bound message", async () => {
+    const appendBoundConversationMessage = vi.fn();
+    const dispatcher = new ChannelDispatcher({
+      manager: makeManager(),
+      resolveBoundConversationId: () => "conversation-group",
+      loadBoundConversationHistory: vi.fn(async () => []),
+      appendBoundConversationMessage,
+      buildAndRunAgent: vi.fn(async () => ({ text: "收到", sticker: null })),
+    });
+
+    await dispatcher.handleIncoming(makeIncoming({
+      channel: "qq",
+      chatType: "group",
+      senderId: "10001",
+      senderName: "小明",
+      chatId: "20001",
+      text: "大家好",
+    }));
+
+    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(1, "conversation-group", "user", "大家好", {
+      channel: "qq",
+      senderName: "小明",
+      modelContext: "[群聊发送者：小明 (10001)]\n大家好",
+    });
   });
 
   it("falls back to channel history when bound desktop history cannot be loaded", async () => {

--- a/src/main/channels/dispatcher.ts
+++ b/src/main/channels/dispatcher.ts
@@ -172,6 +172,12 @@ export function resolveStickerImagePath(stickerId: string): string | null {
 }
 
 /** Dispatcher 配置（依赖注入）。 */
+export interface BoundConversationMessageMetadata {
+  channel: ChannelId;
+  senderName?: string;
+  modelContext?: string;
+}
+
 export interface DispatcherDeps {
   manager: ChannelManager;
   /** 渲染端 chatWindow 用于镜像显示（可选） */
@@ -193,6 +199,7 @@ export interface DispatcherDeps {
     conversationId: string,
     role: "user" | "assistant",
     content: string,
+    metadata: BoundConversationMessageMetadata,
   ) => void | Promise<void>;
   /** 可选 — 把文本合成成音频。失败返回 null，dispatcher 会跳过 audio。 */
   synthesizeTts?: (text: string, context: DispatcherTtsContext) => Promise<Buffer | DispatcherTtsResult | null>;
@@ -358,7 +365,12 @@ export class ChannelDispatcher {
     }
     if (boundConversationId && this.deps.appendBoundConversationMessage) {
       try {
-        await this.deps.appendBoundConversationMessage(boundConversationId, "user", formatChannelUserText(msg));
+        const agentUserText = formatChannelUserText(msg);
+        await this.deps.appendBoundConversationMessage(boundConversationId, "user", msg.text, {
+          channel: msg.channel,
+          senderName: msg.senderName,
+          modelContext: agentUserText === msg.text ? undefined : agentUserText,
+        });
       } catch (err) {
         console.warn(LOG, "appendBoundConversationMessage (incoming) 失败:", err);
       }
@@ -482,7 +494,11 @@ export class ChannelDispatcher {
     }
     if (boundConversationId && this.deps.appendBoundConversationMessage) {
       try {
-        await this.deps.appendBoundConversationMessage(boundConversationId, "assistant", replyText);
+        await this.deps.appendBoundConversationMessage(boundConversationId, "assistant", replyText, {
+          channel: msg.channel,
+          senderName: msg.senderName,
+          modelContext: undefined,
+        });
       } catch (err) {
         console.warn(LOG, "appendBoundConversationMessage (outgoing) 失败:", err);
       }
@@ -611,6 +627,7 @@ export function setDispatcherAppendBoundConversationMessage(
     conversationId: string,
     role: "user" | "assistant",
     content: string,
+    metadata: BoundConversationMessageMetadata,
   ) => void | Promise<void>,
 ): void {
   channelDispatcher.deps.appendBoundConversationMessage = fn;

--- a/src/renderer/react/features/chat/components/ChatMessageList.css
+++ b/src/renderer/react/features/chat/components/ChatMessageList.css
@@ -74,6 +74,23 @@
   gap: 10px;
 }
 
+.cy-message__channel-source {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  color: currentColor;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
+  opacity: 0.68;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cy-message--assistant .cy-message__channel-source {
+  color: var(--cy-text-secondary);
+}
+
 .cy-message__attachments {
   display: flex;
   max-width: min(360px, 55vw);

--- a/src/renderer/react/features/chat/components/ChatMessageList.test.ts
+++ b/src/renderer/react/features/chat/components/ChatMessageList.test.ts
@@ -16,7 +16,7 @@ vi.mock("@ant-design/x-markdown", () => ({ XMarkdown: ({ content }: { content?: 
 vi.mock("@ant-design/x-markdown/plugins/Latex", () => ({ default: () => ({}) }));
 vi.mock("../../../../../shared/renderer-base", () => ({ resolveAsset: (path: string) => path }));
 
-import { createMessageItems, RunActivityDetail, type ChatMessageItem } from "./ChatMessageList";
+import { createMessageItems, formatChannelSourceLabel, RunActivityDetail, type ChatMessageItem } from "./ChatMessageList";
 import { extractMessageStickerId, stripMessageStickerMarkers } from "./message-sticker";
 
 describe("React chat sticker messages", () => {
@@ -42,6 +42,32 @@ describe("formal answer visibility", () => {
     };
 
     expect(createMessageItems([message], []).map((item) => item.role)).toEqual(["activity"]);
+  });
+});
+
+describe("bound channel message presentation", () => {
+  it("uses compact human-readable labels for incoming and outgoing messages", () => {
+    expect(formatChannelSourceLabel({ channel: "wechat", senderName: "伙伴" }, "incoming")).toBe("微信 · 伙伴");
+    expect(formatChannelSourceLabel({ channel: "qq" }, "incoming")).toBe("来自QQ");
+    expect(formatChannelSourceLabel({ channel: "qq" }, "outgoing")).toBe("已回复至QQ");
+  });
+
+  it("falls back safely when persisted channel metadata is invalid", () => {
+    expect(formatChannelSourceLabel({ channel: "unknown" } as never, "incoming")).toBe("来自外部渠道");
+  });
+
+  it("keeps the visible text clean and carries channel source metadata to the bubble", () => {
+    const message = {
+      id: "wechat-user",
+      role: "user",
+      content: "下午见",
+      channelSource: { channel: "wechat", senderName: "伙伴" },
+    } as ChatMessageItem;
+
+    const [item] = createMessageItems([message], []);
+
+    expect(item.content).toBe("下午见");
+    expect(item.extraInfo?.channelSource).toEqual({ channel: "wechat", senderName: "伙伴" });
   });
 });
 

--- a/src/renderer/react/features/chat/components/ChatMessageList.tsx
+++ b/src/renderer/react/features/chat/components/ChatMessageList.tsx
@@ -5,7 +5,7 @@ import { Component, createContext, useCallback, useContext, useEffect, useMemo, 
 import { t, useTranslation } from "../../../i18n";
 import { normalizeModelMarkdown } from "./markdown-normalize";
 import { resolveAsset } from "../../../../../shared/renderer-base";
-import type { AgentRoundRecord, ConversationMode, ProcessMessageRecord, ReasoningBlock, RunActivityRecord, TaskDelegationDisplayRecord, ToolExecutionRecord, ToolFileChange } from "../../../../../shared/chat-types";
+import type { AgentRoundRecord, ChatMessageChannelSource, ConversationMode, ProcessMessageRecord, ReasoningBlock, RunActivityRecord, TaskDelegationDisplayRecord, ToolExecutionRecord, ToolFileChange } from "../../../../../shared/chat-types";
 import type { ContextUsageSnapshot } from "../../../../../shared/context-usage";
 import thinkingMoodUrl from "../../../assets/status-moods/思考中.png?url";
 import completedThinkingMoodUrl from "../../../assets/status-moods/提醒.png?url";
@@ -66,6 +66,9 @@ export interface ChatMessageItem {
   weather?: WeatherData;
   /** 上下文容量快照：运行中为每轮 preRequest 实时值，run 结束后为终态快照。 */
   contextUsage?: ContextUsageSnapshot;
+  /** 渠道群聊的发送者/引用等隐藏模型上下文；不直接渲染。 */
+  modelContext?: string;
+  channelSource?: ChatMessageChannelSource;
 }
 
 export interface ChatMessageAttachment {
@@ -185,18 +188,50 @@ function AssistantContent({
   content,
   streaming,
   stickerUrl,
+  channelSource,
 }: {
   content: string;
   streaming: boolean;
   stickerUrl?: string;
+  channelSource?: ChatMessageChannelSource;
 }) {
   const { t } = useTranslation();
   return (
     <div className="cy-message__assistant-body">
+      {channelSource && <ChannelSourceLabel source={channelSource} direction="outgoing" />}
       {content && <MarkdownContent content={content} streaming={streaming} />}
       {stickerUrl && <img className="cy-message__sticker" src={stickerUrl} alt={t("messageList.assistantStickerAlt")} draggable={false} />}
     </div>
   );
+}
+
+const channelNameKeys: Record<ChatMessageChannelSource["channel"], string> = {
+  wechat: "messageList.channelSource.wechat",
+  feishu: "messageList.channelSource.feishu",
+  qq: "messageList.channelSource.qq",
+  qqbot: "messageList.channelSource.qqbot",
+};
+
+function ChannelSourceLabel({
+  source,
+  direction,
+}: {
+  source: ChatMessageChannelSource;
+  direction: "incoming" | "outgoing";
+}) {
+  return <span className="cy-message__channel-source">{formatChannelSourceLabel(source, direction)}</span>;
+}
+
+export function formatChannelSourceLabel(
+  source: ChatMessageChannelSource,
+  direction: "incoming" | "outgoing",
+): string {
+  const channelKey = channelNameKeys[source.channel];
+  const channelName = channelKey ? t(channelKey) : t("messageList.channelSource.unknown");
+  if (direction === "outgoing") return t("messageList.channelSource.outgoing", { channel: channelName });
+  return source.senderName
+    ? t("messageList.channelSource.incomingSender", { channel: channelName, sender: source.senderName })
+    : t("messageList.channelSource.incoming", { channel: channelName });
 }
 
 function DotSpinner() {
@@ -621,14 +656,17 @@ function UserContent({
   content,
   stickerUrl,
   attachments = [],
+  channelSource,
 }: {
   content: string;
   stickerUrl?: string;
   attachments?: ChatMessageAttachment[];
+  channelSource?: ChatMessageChannelSource;
 }) {
   const { t } = useTranslation();
   return (
     <div className="cy-message__user-body">
+      {channelSource && <ChannelSourceLabel source={channelSource} direction="incoming" />}
       <UserAttachments attachments={attachments} />
       {content && <MarkdownContent content={content} />}
       {stickerUrl && <img className="cy-message__sticker" src={stickerUrl} alt={t("messageList.userStickerAlt")} draggable={false} />}
@@ -715,7 +753,7 @@ function createRoles(
     variant: "filled" as const,
     rootClassName: "cy-message cy-message--user",
     avatar: <UserMessageAvatar src={userAvatarUrl} />,
-    contentRender: (content: string, info: { extraInfo?: { messageId?: string; stickerUrl?: string; attachments?: ChatMessageAttachment[] } }) => (
+    contentRender: (content: string, info: { extraInfo?: { messageId?: string; stickerUrl?: string; attachments?: ChatMessageAttachment[]; channelSource?: ChatMessageChannelSource } }) => (
       info.extraInfo?.messageId === editingMessageId
         ? <LastUserMessageEditor
             value={editDraft}
@@ -728,6 +766,7 @@ function createRoles(
             content={content}
             stickerUrl={info.extraInfo?.stickerUrl}
             attachments={info.extraInfo?.attachments}
+            channelSource={info.extraInfo?.channelSource}
           />
     ),
     footer: (content: string, info: { extraInfo?: { messageId?: string } }) => {
@@ -753,11 +792,12 @@ function createRoles(
     variant: "filled" as const,
     rootClassName: "cy-message cy-message--assistant",
     avatar: <CyreneMessageAvatar />,
-    contentRender: (content: string, info: { extraInfo?: { streaming?: boolean; stickerUrl?: string } }) => (
+    contentRender: (content: string, info: { extraInfo?: { streaming?: boolean; stickerUrl?: string; channelSource?: ChatMessageChannelSource } }) => (
       <AssistantContent
         content={content}
         streaming={Boolean(info.extraInfo?.streaming)}
         stickerUrl={info.extraInfo?.stickerUrl}
+        channelSource={info.extraInfo?.channelSource}
       />
     ),
     footer: (content: string, info: { extraInfo?: { messageId?: string; streaming?: boolean; ttsCacheKey?: string } }) => {
@@ -896,6 +936,7 @@ export function createMessageItems(messages: ChatMessageItem[], enabledStickers:
           stickerUrl: stickerId ? resolveStickerUrl(stickerId, enabledStickers) : undefined,
           attachments: message.attachments,
           messageId: message.id,
+          channelSource: message.channelSource,
         },
       }];
     }
@@ -973,6 +1014,7 @@ export function createMessageItems(messages: ChatMessageItem[], enabledStickers:
           streaming: message.streaming,
           ttsCacheKey: message.ttsCacheKey,
           stickerUrl: message.sticker ? resolveStickerUrl(message.sticker, enabledStickers) : undefined,
+          channelSource: message.channelSource,
         },
       });
     }

--- a/src/renderer/react/features/chat/components/last-turn-actions.test.ts
+++ b/src/renderer/react/features/chat/components/last-turn-actions.test.ts
@@ -47,4 +47,18 @@ describe("resolveRevisableLastTurn", () => {
       { id: "u4", role: "user", content: "还没有回复" },
     ], "chat")).toBeNull();
   });
+
+  it("does not expose actions when the final user message came from a bound channel", () => {
+    expect(resolveRevisableLastTurn([
+      { id: "u3", role: "user", content: "微信消息", channelSource: { channel: "wechat" as const } },
+      { id: "a3", role: "assistant", content: "渠道回复" },
+    ], "chat")).toBeNull();
+  });
+
+  it("does not expose actions when the final assistant message is mirrored to a bound channel", () => {
+    expect(resolveRevisableLastTurn([
+      { id: "u3", role: "user", content: "渠道消息" },
+      { id: "a3", role: "assistant", content: "QQ 回复", channelSource: { channel: "qq" as const } },
+    ], "chat")).toBeNull();
+  });
 });

--- a/src/renderer/react/features/chat/components/last-turn-actions.ts
+++ b/src/renderer/react/features/chat/components/last-turn-actions.ts
@@ -1,4 +1,4 @@
-import type { ConversationMode } from "../../../../../shared/chat-types";
+import type { ChatMessageChannelSource, ConversationMode } from "../../../../../shared/chat-types";
 
 interface RevisableMessage {
   id: string;
@@ -6,6 +6,7 @@ interface RevisableMessage {
   loading?: boolean;
   streaming?: boolean;
   reasoningStreaming?: boolean;
+  channelSource?: ChatMessageChannelSource;
 }
 
 export interface RevisableLastTurn {
@@ -21,6 +22,9 @@ export function resolveRevisableLastTurn(
   const user = messages[messages.length - 2];
   const assistant = messages[messages.length - 1];
   if (user.role !== "user" || (assistant.role !== "assistant" && assistant.role !== "model")) return null;
+  // 渠道镜像轮次只能展示。桌面端编辑/重新生成会改用桌面会话身份执行，
+  // 既不会回发原渠道，也可能让可见正文与渠道模型上下文失配。
+  if (user.channelSource || assistant.channelSource) return null;
   if (assistant.loading || assistant.streaming || assistant.reasoningStreaming) return null;
   return {
     userMessageId: user.id,

--- a/src/renderer/react/features/chat/pages/chat-page-normalizers.test.ts
+++ b/src/renderer/react/features/chat/pages/chat-page-normalizers.test.ts
@@ -1,7 +1,74 @@
 import { describe, expect, it, vi } from "vitest";
-import { getInitialMode, LAST_MODE_STORAGE_KEY, normalizeWeatherData, stageForStep } from "./chat-page-normalizers";
+import type { ChatSession } from "../../../../../shared/chat-types";
+import { getInitialMode, LAST_MODE_STORAGE_KEY, normalizeWeatherData, stageForStep, toUiMessages } from "./chat-page-normalizers";
 
 describe("chat page normalizers", () => {
+  it("preserves channel source metadata while hydrating a bound conversation", () => {
+    const session: ChatSession = {
+      id: "conversation-1",
+      title: "微信会话",
+      identityId: null,
+      mode: "chat",
+      schemaVersion: 1,
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [{
+        id: "message-1",
+        role: "user",
+        content: "你好",
+        at: 2,
+        channelSource: { channel: "wechat", senderName: "伙伴" },
+      }],
+    };
+    const [message] = toUiMessages(session);
+
+    expect(message.channelSource).toEqual({ channel: "wechat", senderName: "伙伴" });
+    expect(message.modelContext).toBeUndefined();
+  });
+
+  it("preserves hidden model context for desktop continuation", () => {
+    const session: ChatSession = {
+      id: "conversation-1",
+      title: "群聊会话",
+      identityId: null,
+      mode: "chat",
+      schemaVersion: 1,
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [{
+        id: "message-1",
+        role: "user",
+        content: "大家好",
+        modelContext: "[QQ群发送者：伙伴]\n大家好",
+        channelSource: { channel: "qq", senderName: "伙伴" },
+        at: 2,
+      }],
+    };
+
+    expect(toUiMessages(session)[0].modelContext).toBe("[QQ群发送者：伙伴]\n大家好");
+  });
+
+  it("drops invalid persisted channel metadata during hydration", () => {
+    const session: ChatSession = {
+      id: "conversation-1",
+      title: "旧会话",
+      identityId: null,
+      mode: "chat",
+      schemaVersion: 1,
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [{
+        id: "message-1",
+        role: "user",
+        content: "旧消息",
+        at: 2,
+        channelSource: { channel: "broken" },
+      }],
+    } as unknown as ChatSession;
+
+    expect(toUiMessages(session)[0].channelSource).toBeUndefined();
+  });
+
   it("normalizes a complete Open-Meteo weather card", () => {
     expect(normalizeWeatherData({
       source: "open-meteo",

--- a/src/renderer/react/features/chat/pages/chat-page-normalizers.ts
+++ b/src/renderer/react/features/chat/pages/chat-page-normalizers.ts
@@ -1,4 +1,4 @@
-import type { ChatSession, ConversationMode } from "../../../../../shared/chat-types";
+import type { ChatMessageChannelSource, ChatSession, ConversationMode } from "../../../../../shared/chat-types";
 import type { ChatMessageItem } from "../components/ChatMessageList";
 import {
   describePermissionRequest,
@@ -10,11 +10,24 @@ import type { PermissionApprovalRequest } from "./chat-page-bridge";
 import { recoverInterruptedMessage } from "./session-runtime-state";
 
 const CONVERSATION_MODES: readonly ConversationMode[] = ["chat", "work", "code", "learn"];
+const CHAT_MESSAGE_CHANNELS = new Set<ChatMessageChannelSource["channel"]>(["wechat", "feishu", "qq", "qqbot"]);
 /** 最后停留模式的 localStorage 键：写入方（ChatPage）与读取方（getInitialMode）共用同一常量。 */
 export const LAST_MODE_STORAGE_KEY = "cyrene-react-last-mode";
 
 export function isConversationMode(value: string): value is ConversationMode {
   return CONVERSATION_MODES.includes(value as ConversationMode);
+}
+
+function normalizeChannelSource(value: unknown): ChatMessageChannelSource | undefined {
+  const record = asRecord(value);
+  if (!record || typeof record.channel !== "string" || !CHAT_MESSAGE_CHANNELS.has(record.channel as ChatMessageChannelSource["channel"])) {
+    return undefined;
+  }
+  const senderName = asNonEmptyString(record.senderName);
+  return {
+    channel: record.channel as ChatMessageChannelSource["channel"],
+    ...(senderName ? { senderName } : {}),
+  };
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -115,6 +128,8 @@ export function toUiMessages(session: ChatSession): ChatMessageItem[] {
       id: message.id,
       role: message.role === "model" ? "assistant" : "user",
       content: message.content,
+      modelContext: message.modelContext,
+      channelSource: normalizeChannelSource(message.channelSource),
       reasoning: message.reasoning,
       reasoningBlocks: message.reasoningBlocks,
       processMessages: message.processMessages,

--- a/src/renderer/react/features/chat/pages/run/AgentRunController.test.ts
+++ b/src/renderer/react/features/chat/pages/run/AgentRunController.test.ts
@@ -127,6 +127,43 @@ afterEach(() => {
 });
 
 describe("AgentRunController", () => {
+  it("uses hidden channel model context when continuing a bound conversation from desktop", async () => {
+    const api = createFakeApi({ success: true, runId: "run-1" });
+    const store = createFakeStore();
+    const { host } = createRecordingHost();
+    const input = createInput({
+      session: {
+        id: "session-1",
+        messages: [
+          {
+            id: "channel-user",
+            role: "user",
+            content: "大家好",
+            modelContext: "[QQ群发送者：伙伴]\n大家好",
+            channelSource: { channel: "qq", senderName: "伙伴" },
+            at: 1,
+          },
+          { id: "channel-model", role: "model", content: "你好", channelSource: { channel: "qq" }, at: 2 },
+          { id: "user-1", role: "user", content: "继续说", at: 3 },
+        ],
+      } as unknown as ChatSession,
+    });
+    const { promise } = launch(input, { api, store, host, registries: createRegistries() });
+    await flush();
+
+    expect(api.run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [
+        expect.objectContaining({ role: "user", content: "[QQ群发送者：伙伴]\n大家好" }),
+        expect.objectContaining({ role: "model", content: "你好" }),
+        expect.objectContaining({ role: "user", content: "继续说" }),
+      ],
+    }));
+
+    api.emit(RUN_STARTED_EVENT);
+    api.emit({ type: "RUN_FINISHED", runId: "run-1", result: { status: "success" } });
+    await promise;
+  });
+
   it("桥或存储未就绪时直接把错误写进消息并落盘，不进入 run 流程", async () => {
     const input = createInput();
     const store = createFakeStore();

--- a/src/renderer/react/features/chat/pages/run/AgentRunController.ts
+++ b/src/renderer/react/features/chat/pages/run/AgentRunController.ts
@@ -210,7 +210,7 @@ export class AgentRunController {
       const ack = await api.run({
         messages: this.input.session.messages.slice(-16).map((item) => ({
           role: item.role,
-          content: item.content,
+          content: item.modelContext?.trim() || item.content,
           at: item.at,
         })),
         userTurnId: this.input.userMessageId,

--- a/src/renderer/react/i18n/zh-CN.json
+++ b/src/renderer/react/i18n/zh-CN.json
@@ -97,7 +97,17 @@
     "svgCardPending": "卡片生成中…",
     "svgCardFallback": "SVG 内容无效或过长，已降级为源码显示",
     "diagramPreview": "图表预览",
-    "diagramZoomHint": "点击放大查看"
+    "diagramZoomHint": "点击放大查看",
+    "channelSource": {
+      "wechat": "微信",
+      "feishu": "飞书",
+      "qq": "QQ",
+      "qqbot": "QQ Bot",
+      "unknown": "外部渠道",
+      "incoming": "来自{{channel}}",
+      "incomingSender": "{{channel}} · {{sender}}",
+      "outgoing": "已回复至{{channel}}"
+    }
   },
   "contextRing": {
     "categorySystemPrompt": "系统提示词",

--- a/src/shared/chat-types.ts
+++ b/src/shared/chat-types.ts
@@ -106,6 +106,14 @@ export interface TaskDelegationDisplayRecord extends TaskDelegationPresentation 
   roundId?: string;
 }
 
+export type ChatMessageChannel = "wechat" | "feishu" | "qq" | "qqbot";
+
+/** 外部渠道镜像来源。只用于展示，不改变桌面对话或渠道 Agent 的运行身份。 */
+export interface ChatMessageChannelSource {
+  channel: ChatMessageChannel;
+  senderName?: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: ChatRole;
@@ -122,6 +130,8 @@ export interface ChatMessage {
   at: number;
   /** 不直接显示在聊天气泡里，但会拼入模型上下文。 */
   modelContext?: string;
+  /** 绑定的微信/QQ等渠道来源；正文保持为用户实际发送的内容。 */
+  channelSource?: ChatMessageChannelSource;
   attachments?: MessageAttachment[];
   /** 表情包 ID（内置或用户自定义） */
   sticker?: string | null;


### PR DESCRIPTION
关联 #61。

这个改动让绑定到桌面对话的微信、QQ、飞书消息直接显示为普通聊天气泡。气泡正文只保留实际消息，来源和发送者以较轻的标签显示，回复也会标明发送到哪个渠道。

群聊发送者和引用信息保存在隐藏的模型上下文中，桌面端继续该对话时仍能正确理解前文，但这些信息不会混入气泡正文。绑定只共享对话文本，不会继承桌面对话的工具权限、执行模式或工作区。

渠道镜像的最后一轮不会显示编辑和重新生成入口，避免在桌面身份下重跑后无法回发原渠道。旧会话保持兼容，异常渠道元数据会被忽略。

已通过 67 个相关测试，主进程和渲染进程构建通过。完整测试中 3633 项通过，唯一失败是本机 WSL 启动警告写入 stderr，与本次改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 聊天消息现显示来源渠道及发送者信息，支持微信、飞书、QQ 和 QQ Bot。
  - 渠道消息历史与后续对话可保留原始文本、发送者及上下文信息。
  - 支持绑定会话续聊时正确恢复渠道消息内容。
- **体验优化**
  - 渠道来源采用本地化标签展示，不改变消息正文。
  - 外部渠道镜像消息不再支持编辑或重新生成，避免误操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->