### PR TITLE
优化渠道绑定会话的来源提示和表情展示

### DIFF
--- a/src/main/channels/bootstrap.test.ts
+++ b/src/main/channels/bootstrap.test.ts
@@ -11,7 +11,7 @@ const channelMocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   appendMessage: vi.fn(),
   loadBoundConversationHistory: undefined as ((conversationId: string, limit: number) => Promise<Array<{ role: "user" | "assistant"; content: string }>>) | undefined,
-  appendBoundConversationMessage: undefined as ((conversationId: string, role: "user" | "assistant", content: string, metadata: { channel: "wechat" | "feishu" | "qq" | "qqbot"; senderName?: string; modelContext?: string }) => void) | undefined,
+  appendBoundConversationMessage: undefined as ((conversationId: string, role: "user" | "assistant", content: string, metadata: { channel: "wechat" | "feishu" | "qq" | "qqbot"; chatType: "private" | "group"; senderName?: string; modelContext?: string; sticker?: string }) => void) | undefined,
   buildAndRunAgent: undefined as ((...args: unknown[]) => Promise<unknown>) | undefined,
   agentError: undefined as Error | undefined,
   agentResult: { reply: "渠道回复", toolResults: [] } as {
@@ -169,15 +169,18 @@ describe("createChannelsSubsystem lifecycle", () => {
 
     channelMocks.appendBoundConversationMessage?.("desktop-1", "user", "大家好", {
       channel: "qq",
+      chatType: "group",
       senderName: "伙伴",
       modelContext: "[QQ群发送者：伙伴]\n大家好",
+      sticker: "OK",
     });
 
     expect(channelMocks.appendMessage).toHaveBeenCalledWith("desktop-1", expect.objectContaining({
       role: "user",
       content: "大家好",
       modelContext: "[QQ群发送者：伙伴]\n大家好",
-      channelSource: { channel: "qq", senderName: "伙伴" },
+      channelSource: { channel: "qq", chatType: "group", senderName: "伙伴" },
+      sticker: "OK",
     }));
   });
 

--- a/src/main/channels/bootstrap.ts
+++ b/src/main/channels/bootstrap.ts
@@ -112,8 +112,10 @@ export function createChannelsSubsystem(
       content,
       at: Date.now(),
       modelContext: metadata.modelContext,
+      sticker: metadata.sticker,
       channelSource: {
         channel: metadata.channel,
+        chatType: metadata.chatType,
         senderName: metadata.senderName,
       },
     });

--- a/src/main/channels/dispatcher.test.ts
+++ b/src/main/channels/dispatcher.test.ts
@@ -134,11 +134,13 @@ describe("channels/dispatcher", () => {
     expect(loadBoundConversationHistory).toHaveBeenCalledWith("conversation-7", 16);
     expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(1, "conversation-7", "user", "你好", {
       channel,
+      chatType: "private",
       senderName: "测试用户",
       modelContext: undefined,
     });
     expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(2, "conversation-7", "assistant", "共享回复", {
       channel,
+      chatType: "private",
       senderName: "测试用户",
       modelContext: undefined,
     });
@@ -166,9 +168,43 @@ describe("channels/dispatcher", () => {
 
     expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(1, "conversation-group", "user", "大家好", {
       channel: "qq",
+      chatType: "group",
       senderName: "小明",
       modelContext: "[群聊发送者：小明 (10001)]\n大家好",
     });
+  });
+
+  it("persists the same selected built-in sticker in the bound desktop reply", async () => {
+    const appendBoundConversationMessage = vi.fn();
+    const dispatcher = new ChannelDispatcher({
+      manager: { getAdapter: () => ({ capability: { text: true, image: true, audio: false, file: false, video: false, markdown: false, card: false, sticker: true, maxTextLength: 2048 } }) } as any,
+      resolveBoundConversationId: () => "conversation-sticker",
+      loadBoundConversationHistory: vi.fn(async () => []),
+      appendBoundConversationMessage,
+      buildAndRunAgent: vi.fn(async () => ({ text: "收到", sticker: "OK" })),
+    });
+
+    await dispatcher.handleIncoming(makeIncoming({ channel: "wechat" }));
+
+    expect(appendBoundConversationMessage).toHaveBeenNthCalledWith(2, "conversation-sticker", "assistant", "收到", expect.objectContaining({
+      channel: "wechat",
+      sticker: "OK",
+    }));
+  });
+
+  it("does not persist a selected sticker when the channel capability rejects stickers", async () => {
+    const appendBoundConversationMessage = vi.fn();
+    const dispatcher = new ChannelDispatcher({
+      manager: makeManager(),
+      resolveBoundConversationId: () => "conversation-no-sticker",
+      loadBoundConversationHistory: vi.fn(async () => []),
+      appendBoundConversationMessage,
+      buildAndRunAgent: vi.fn(async () => ({ text: "收到", sticker: "OK" })),
+    });
+
+    await dispatcher.handleIncoming(makeIncoming());
+
+    expect(appendBoundConversationMessage.mock.calls[1]?.[3]).not.toHaveProperty("sticker");
   });
 
   it("falls back to channel history when bound desktop history cannot be loaded", async () => {

--- a/src/main/channels/dispatcher.ts
+++ b/src/main/channels/dispatcher.ts
@@ -174,8 +174,11 @@ export function resolveStickerImagePath(stickerId: string): string | null {
 /** Dispatcher 配置（依赖注入）。 */
 export interface BoundConversationMessageMetadata {
   channel: ChannelId;
+  chatType: "private" | "group";
   senderName?: string;
   modelContext?: string;
+  /** 昔涟本轮选择、且目标渠道声明可发送的内置或用户表情包 ID。 */
+  sticker?: string;
 }
 
 export interface DispatcherDeps {
@@ -368,6 +371,7 @@ export class ChannelDispatcher {
         const agentUserText = formatChannelUserText(msg);
         await this.deps.appendBoundConversationMessage(boundConversationId, "user", msg.text, {
           channel: msg.channel,
+          chatType: msg.chatType ?? "private",
           senderName: msg.senderName,
           modelContext: agentUserText === msg.text ? undefined : agentUserText,
         });
@@ -443,11 +447,14 @@ export class ChannelDispatcher {
     // sticker 决定纳入 OutgoingMessage.parts（统一消息模型）。
     // 由 onAgentRunFinished 计算（同一个 embedding 匹配结果，避免重复计算），
     // dispatcher 只负责解析本地路径 + 按 cap 降级。
-    // 桌面聊天窗的 sticker 由 onAgentRunFinished 内部 IPC 广播承担，此处不重复。
+    // 普通桌面 AG-UI 会话由 onAgentRunFinished 的 IPC 展示；渠道绑定会话则在下方
+    // 与 replyText 一起持久化选中的 stickerId，两条路径不会重复经过同一会话。
+    let resolvedStickerId: string | undefined;
     if (sticker && this.settings.stickerEnabled) {
       const stickerPath = resolveStickerImagePath(sticker);
       if (stickerPath) {
         parts.push({ kind: "sticker", stickerId: sticker, imagePath: stickerPath });
+        resolvedStickerId = sticker;
         console.log(LOG, `sticker 决定: id=${sticker} → ${stickerPath}`);
       } else {
         console.warn(LOG, `sticker 解析失败（跳过）: id=${sticker}`);
@@ -496,8 +503,10 @@ export class ChannelDispatcher {
       try {
         await this.deps.appendBoundConversationMessage(boundConversationId, "assistant", replyText, {
           channel: msg.channel,
+          chatType: msg.chatType ?? "private",
           senderName: msg.senderName,
           modelContext: undefined,
+          ...(resolvedStickerId && adapterCap?.sticker !== false ? { sticker: resolvedStickerId } : {}),
         });
       } catch (err) {
         console.warn(LOG, "appendBoundConversationMessage (outgoing) 失败:", err);

--- a/src/renderer/react/features/chat/components/ChatMessageList.css
+++ b/src/renderer/react/features/chat/components/ChatMessageList.css
@@ -11,6 +11,41 @@
   min-height: 100%;
 }
 
+.cy-message-list__channel-context {
+  position: sticky;
+  z-index: 2;
+  top: 8px;
+  display: flex;
+  width: max-content;
+  max-width: min(100%, 360px);
+  align-items: center;
+  gap: 8px;
+  margin: 0 auto 16px;
+  padding: 6px 12px;
+  border: 1px solid var(--cy-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cy-bg-workspace) 88%, transparent);
+  box-shadow: 0 4px 16px rgb(43 33 54 / 8%);
+  color: var(--cy-text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  backdrop-filter: blur(12px);
+}
+
+.cy-message-list__channel-context > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cy-message-list__channel-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-radius: 50%;
+  background: var(--cy-accent);
+}
+
 .cy-message {
   width: 100%;
   max-width: none;

--- a/src/renderer/react/features/chat/components/ChatMessageList.test.ts
+++ b/src/renderer/react/features/chat/components/ChatMessageList.test.ts
@@ -16,7 +16,7 @@ vi.mock("@ant-design/x-markdown", () => ({ XMarkdown: ({ content }: { content?: 
 vi.mock("@ant-design/x-markdown/plugins/Latex", () => ({ default: () => ({}) }));
 vi.mock("../../../../../shared/renderer-base", () => ({ resolveAsset: (path: string) => path }));
 
-import { createMessageItems, formatChannelSourceLabel, RunActivityDetail, type ChatMessageItem } from "./ChatMessageList";
+import { createMessageItems, formatChannelSourceLabel, resolveChannelConversationLabel, RunActivityDetail, type ChatMessageItem } from "./ChatMessageList";
 import { extractMessageStickerId, stripMessageStickerMarkers } from "./message-sticker";
 
 describe("React chat sticker messages", () => {
@@ -46,14 +46,31 @@ describe("formal answer visibility", () => {
 });
 
 describe("bound channel message presentation", () => {
-  it("uses compact human-readable labels for incoming and outgoing messages", () => {
-    expect(formatChannelSourceLabel({ channel: "wechat", senderName: "伙伴" }, "incoming")).toBe("微信 · 伙伴");
-    expect(formatChannelSourceLabel({ channel: "qq" }, "incoming")).toBe("来自QQ");
-    expect(formatChannelSourceLabel({ channel: "qq" }, "outgoing")).toBe("已回复至QQ");
+  it("shows a sender only for group messages instead of repeating channel status", () => {
+    expect(formatChannelSourceLabel({ channel: "wechat", chatType: "group", senderName: "伙伴" }, "incoming")).toBe("伙伴");
+    expect(formatChannelSourceLabel({ channel: "wechat", chatType: "private", senderName: "伙伴" }, "incoming")).toBe("");
+    expect(formatChannelSourceLabel({ channel: "qq", senderName: "旧消息昵称" }, "incoming")).toBe("");
+    expect(formatChannelSourceLabel({ channel: "qq" }, "outgoing")).toBe("");
   });
 
   it("falls back safely when persisted channel metadata is invalid", () => {
-    expect(formatChannelSourceLabel({ channel: "unknown" } as never, "incoming")).toBe("来自外部渠道");
+    expect(formatChannelSourceLabel({ channel: "unknown" } as never, "incoming")).toBe("");
+  });
+
+  it("summarizes channel context once for the whole conversation", () => {
+    expect(resolveChannelConversationLabel([
+      { id: "u1", role: "user", content: "微信消息", channelSource: { channel: "wechat" } },
+      { id: "a1", role: "assistant", content: "回复", channelSource: { channel: "wechat" } },
+    ])).toBe("微信 · 同一对话");
+
+    expect(resolveChannelConversationLabel([
+      { id: "u1", role: "user", content: "微信消息", channelSource: { channel: "wechat" } },
+      { id: "u2", role: "user", content: "QQ消息", channelSource: { channel: "qq" } },
+    ])).toBe("微信、QQ · 同一对话");
+
+    expect(resolveChannelConversationLabel([
+      { id: "u1", role: "user", content: "普通消息" },
+    ])).toBeNull();
   });
 
   it("keeps the visible text clean and carries channel source metadata to the bubble", () => {
@@ -61,13 +78,13 @@ describe("bound channel message presentation", () => {
       id: "wechat-user",
       role: "user",
       content: "下午见",
-      channelSource: { channel: "wechat", senderName: "伙伴" },
+      channelSource: { channel: "wechat", chatType: "group", senderName: "伙伴" },
     } as ChatMessageItem;
 
     const [item] = createMessageItems([message], []);
 
     expect(item.content).toBe("下午见");
-    expect(item.extraInfo?.channelSource).toEqual({ channel: "wechat", senderName: "伙伴" });
+    expect(item.extraInfo?.channelSource).toEqual({ channel: "wechat", chatType: "group", senderName: "伙伴" });
   });
 });
 

--- a/src/renderer/react/features/chat/components/ChatMessageList.tsx
+++ b/src/renderer/react/features/chat/components/ChatMessageList.tsx
@@ -219,19 +219,36 @@ function ChannelSourceLabel({
   source: ChatMessageChannelSource;
   direction: "incoming" | "outgoing";
 }) {
-  return <span className="cy-message__channel-source">{formatChannelSourceLabel(source, direction)}</span>;
+  const label = formatChannelSourceLabel(source, direction);
+  return label ? <span className="cy-message__channel-source">{label}</span> : null;
 }
 
 export function formatChannelSourceLabel(
   source: ChatMessageChannelSource,
   direction: "incoming" | "outgoing",
 ): string {
-  const channelKey = channelNameKeys[source.channel];
-  const channelName = channelKey ? t(channelKey) : t("messageList.channelSource.unknown");
-  if (direction === "outgoing") return t("messageList.channelSource.outgoing", { channel: channelName });
-  return source.senderName
-    ? t("messageList.channelSource.incomingSender", { channel: channelName, sender: source.senderName })
-    : t("messageList.channelSource.incoming", { channel: channelName });
+  if (direction === "outgoing" || source.chatType !== "group") return "";
+  return source.senderName?.trim() ?? "";
+}
+
+function channelName(channel: ChatMessageChannelSource["channel"]): string {
+  const key = channelNameKeys[channel];
+  return key ? t(key) : t("messageList.channelSource.unknown");
+}
+
+/** 把逐条来源提示收拢为会话级提示，避免每个气泡都像日志。 */
+export function resolveChannelConversationLabel(
+  messages: readonly Pick<ChatMessageItem, "channelSource">[],
+): string | null {
+  const channels = Array.from(new Set(
+    messages
+      .map((message) => message.channelSource?.channel)
+      .filter((channel): channel is ChatMessageChannelSource["channel"] => Boolean(channel)),
+  ));
+  if (channels.length === 0) return null;
+  return t("messageList.channelSource.sameConversation", {
+    channels: channels.map(channelName).join("、"),
+  });
 }
 
 function DotSpinner() {
@@ -1154,6 +1171,7 @@ export function ChatMessageList({
   }, []);
 
   const items = createMessageItems(messages, enabledStickers);
+  const channelConversationLabel = resolveChannelConversationLabel(messages);
 
   return (
     <div
@@ -1162,6 +1180,12 @@ export function ChatMessageList({
       aria-live="polite"
       onScroll={updateScrollState}
     >
+      {channelConversationLabel && (
+        <div className="cy-message-list__channel-context" role="note" aria-label={channelConversationLabel}>
+          <span className="cy-message-list__channel-dot" aria-hidden="true" />
+          <span>{channelConversationLabel}</span>
+        </div>
+      )}
       <Bubble.List items={items} role={roles} autoScroll />
     </div>
   );

--- a/src/renderer/react/features/chat/pages/chat-page-normalizers.test.ts
+++ b/src/renderer/react/features/chat/pages/chat-page-normalizers.test.ts
@@ -17,12 +17,12 @@ describe("chat page normalizers", () => {
         role: "user",
         content: "你好",
         at: 2,
-        channelSource: { channel: "wechat", senderName: "伙伴" },
+        channelSource: { channel: "wechat", chatType: "private", senderName: "伙伴" },
       }],
     };
     const [message] = toUiMessages(session);
 
-    expect(message.channelSource).toEqual({ channel: "wechat", senderName: "伙伴" });
+    expect(message.channelSource).toEqual({ channel: "wechat", chatType: "private", senderName: "伙伴" });
     expect(message.modelContext).toBeUndefined();
   });
 
@@ -40,7 +40,7 @@ describe("chat page normalizers", () => {
         role: "user",
         content: "大家好",
         modelContext: "[QQ群发送者：伙伴]\n大家好",
-        channelSource: { channel: "qq", senderName: "伙伴" },
+        channelSource: { channel: "qq", chatType: "group", senderName: "伙伴" },
         at: 2,
       }],
     };

--- a/src/renderer/react/features/chat/pages/chat-page-normalizers.ts
+++ b/src/renderer/react/features/chat/pages/chat-page-normalizers.ts
@@ -24,8 +24,12 @@ function normalizeChannelSource(value: unknown): ChatMessageChannelSource | unde
     return undefined;
   }
   const senderName = asNonEmptyString(record.senderName);
+  const chatType = record.chatType === "private" || record.chatType === "group"
+    ? record.chatType
+    : undefined;
   return {
     channel: record.channel as ChatMessageChannelSource["channel"],
+    ...(chatType ? { chatType } : {}),
     ...(senderName ? { senderName } : {}),
   };
 }

--- a/src/renderer/react/i18n/zh-CN.json
+++ b/src/renderer/react/i18n/zh-CN.json
@@ -104,9 +104,7 @@
       "qq": "QQ",
       "qqbot": "QQ Bot",
       "unknown": "外部渠道",
-      "incoming": "来自{{channel}}",
-      "incomingSender": "{{channel}} · {{sender}}",
-      "outgoing": "已回复至{{channel}}"
+      "sameConversation": "{{channels}} · 同一对话"
     }
   },
   "contextRing": {

--- a/src/shared/chat-types.ts
+++ b/src/shared/chat-types.ts
@@ -111,6 +111,7 @@ export type ChatMessageChannel = "wechat" | "feishu" | "qq" | "qqbot";
 /** 外部渠道镜像来源。只用于展示，不改变桌面对话或渠道 Agent 的运行身份。 */
 export interface ChatMessageChannelSource {
   channel: ChatMessageChannel;
+  chatType?: "private" | "group";
   senderName?: string;
 }
 


### PR DESCRIPTION
在 #68 的基础上继续调整绑定会话的展示。

主要变化：
- 微信、QQ 等来源改为会话顶部统一提示，避免每条消息重复显示渠道状态
- 私聊不再重复显示发送者，群聊仍保留发送者名称
- 渠道回复选中内置表情时，同步显示在绑定的桌面对话中
- 保持渠道原有 sessionId、工具权限和工作区绑定不变

验证：
- 相关 51 个测试通过
- 主进程与渲染进程构建通过
- 微信实测通过，回复选中的 hugtight 表情已同时写入绑定桌面对话

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持在聊天消息中保留并展示私聊或群聊类型。
  * 群聊入站消息显示发送者名称，并在会话顶部显示统一的渠道来源提示。
  * 在目标渠道支持时，绑定会话可保留贴纸信息。

* **Bug 修复**
  * 改进渠道消息来源数据的校验与展示，避免无效或不适用的来源信息显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->