### PR TITLE
fix(settings): 修复切换设置时隐藏桌宠自动出现

### DIFF
--- a/src/main/settings/general-settings-lifecycle.test.ts
+++ b/src/main/settings/general-settings-lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GeneralSettings } from "./general-settings";
+import type { WindowManager } from "../windows/window-manager";
+import { applyGeneralSettings, handleGeneralSettingsChanged } from "./general-settings-lifecycle";
+import { syncLaunchAtLogin } from "./launch-at-login";
+
+vi.mock("electron", () => ({ app: {}, nativeImage: {} }));
+vi.mock("../windows/broadcast", () => ({ broadcastToAllWindows: vi.fn() }));
+vi.mock("../windows/window-state", () => ({ setGetCurrentAppIconPath: vi.fn() }));
+vi.mock("../locale-context", () => ({ updateLocaleContext: vi.fn() }));
+vi.mock("../orchestrator/mcp-manager", () => ({
+  addMcpServer: vi.fn(), listMcpServers: () => [], removeMcpServer: vi.fn(),
+}));
+vi.mock("../app-icon", () => ({ getAppIconPath: vi.fn() }));
+vi.mock("../orchestrator/tools/registry/tool-registration", () => ({ syncBuiltInToolToggles: vi.fn() }));
+vi.mock("./model-settings", () => ({ loadModelSettings: vi.fn(), getPublicModelConfig: vi.fn() }));
+vi.mock("./launch-at-login", () => ({ syncLaunchAtLogin: vi.fn() }));
+
+function createHarness(petVisible = true) {
+  const settings = {
+    petVisible, petAlwaysOnTop: true, petZoom: 1, launchAtLogin: false,
+    asrEngine: "off", searchEngine: "off",
+  } as GeneralSettings;
+  let visible = petVisible;
+  const windowManager = {
+    showPetWindow: vi.fn(() => { visible = true; }),
+    hidePetWindow: vi.fn(() => { visible = false; }),
+    setPetWindowAlwaysOnTop: vi.fn(),
+    applyPetWindowZoom: vi.fn(),
+  };
+  const deps = {
+    windowManager: windowManager as unknown as WindowManager,
+    tray: null,
+    screenshotService: null,
+    proactiveLifecycle: { getProactiveChatService: () => null },
+    broadcastToAuxWindows: vi.fn(),
+  };
+  return { settings, windowManager, deps, isVisible: () => visible };
+}
+
+describe("general settings window lifecycle", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps a pet hidden from the tray hidden when changing ASR provider (#85)", () => {
+    const h = createHarness();
+    h.windowManager.hidePetWindow();
+    handleGeneralSettingsChanged(h.settings, { ...h.settings, asrEngine: "aliyun" }, h.deps);
+    expect(h.isVisible()).toBe(false);
+    expect(h.windowManager.showPetWindow).not.toHaveBeenCalled();
+    expect(h.windowManager.setPetWindowAlwaysOnTop).not.toHaveBeenCalled();
+    expect(h.windowManager.applyPetWindowZoom).not.toHaveBeenCalled();
+    expect(syncLaunchAtLogin).not.toHaveBeenCalled();
+  });
+
+  it("keeps a temporarily shown pet visible when unrelated settings are saved", () => {
+    const h = createHarness(false);
+    h.windowManager.showPetWindow();
+    handleGeneralSettingsChanged(h.settings, { ...h.settings, asrEngine: "local" }, h.deps);
+    expect(h.isVisible()).toBe(true);
+    expect(h.windowManager.hidePetWindow).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("applies an explicit visibility change to %s", (visible) => {
+    const h = createHarness(!visible);
+    handleGeneralSettingsChanged(h.settings, { ...h.settings, petVisible: visible }, h.deps);
+    expect(h.isVisible()).toBe(visible);
+    expect(visible ? h.windowManager.showPetWindow : h.windowManager.hidePetWindow).toHaveBeenCalledOnce();
+  });
+
+  it("applies changed window preferences without revealing a hidden pet", () => {
+    const h = createHarness();
+    h.windowManager.hidePetWindow();
+    handleGeneralSettingsChanged(h.settings, {
+      ...h.settings, petAlwaysOnTop: false, petZoom: 1.5, launchAtLogin: true,
+    }, h.deps);
+    expect(h.isVisible()).toBe(false);
+    expect(h.windowManager.setPetWindowAlwaysOnTop).toHaveBeenCalledWith(false);
+    expect(h.windowManager.applyPetWindowZoom).toHaveBeenCalledWith(1.5);
+    expect(syncLaunchAtLogin).toHaveBeenCalledWith(true, {});
+  });
+
+  it.each([true, false])("fully applies startup settings with petVisible=%s", (visible) => {
+    const h = createHarness(visible);
+    applyGeneralSettings(h.settings, h.deps);
+    expect(visible ? h.windowManager.showPetWindow : h.windowManager.hidePetWindow).toHaveBeenCalledOnce();
+    expect(h.windowManager.setPetWindowAlwaysOnTop).toHaveBeenCalledWith(true);
+    expect(h.windowManager.applyPetWindowZoom).toHaveBeenCalledWith(1);
+    expect(syncLaunchAtLogin).toHaveBeenCalledWith(false, {});
+  });
+});

--- a/src/main/settings/general-settings-lifecycle.ts
+++ b/src/main/settings/general-settings-lifecycle.ts
@@ -25,12 +25,25 @@ export interface GeneralSettingsLifecycleDependencies {
 /** MiniMax 搜索 MCP Server 的固定 ID。 */
 const MINIMAX_SEARCH_MCP_ID = "minimax-web-search";
 
-export function applyGeneralSettings(settings: GeneralSettings, deps: GeneralSettingsLifecycleDependencies): void {
-  deps.windowManager?.setPetWindowAlwaysOnTop(settings.petAlwaysOnTop);
-  if (settings.petVisible) deps.windowManager?.showPetWindow();
-  else deps.windowManager?.hidePetWindow();
-  syncLaunchAtLogin(settings.launchAtLogin, app);
-  deps.windowManager?.applyPetWindowZoom(settings.petZoom);
+export function applyGeneralSettings(
+  settings: GeneralSettings,
+  deps: GeneralSettingsLifecycleDependencies,
+  before?: GeneralSettings,
+): void {
+  // 启动时完整应用；保存设置时只应用变化项，保留托盘临时隐藏等窗口状态。
+  if (!before || before.petAlwaysOnTop !== settings.petAlwaysOnTop) {
+    deps.windowManager?.setPetWindowAlwaysOnTop(settings.petAlwaysOnTop);
+  }
+  if (!before || before.petVisible !== settings.petVisible) {
+    if (settings.petVisible) deps.windowManager?.showPetWindow();
+    else deps.windowManager?.hidePetWindow();
+  }
+  if (!before || before.launchAtLogin !== settings.launchAtLogin) {
+    syncLaunchAtLogin(settings.launchAtLogin, app);
+  }
+  if (!before || before.petZoom !== settings.petZoom) {
+    deps.windowManager?.applyPetWindowZoom(settings.petZoom);
+  }
 }
 
 export function applyUiIcon(iconSetting: UiIcon, deps: GeneralSettingsLifecycleDependencies): void {
@@ -114,7 +127,7 @@ export function handleGeneralSettingsChanged(
   after: GeneralSettings,
   deps: GeneralSettingsLifecycleDependencies,
 ): void {
-  applyGeneralSettings(after, deps);
+  applyGeneralSettings(after, deps, before);
   syncBuiltInToolToggles(after);
   if (before.language !== after.language || before.asrLanguage !== after.asrLanguage) {
     updateLocaleContext({


### PR DESCRIPTION
## 🔗 相关 Issue

Fixes #85

## 📝 变更说明

通过托盘隐藏桌宠后，切换 ASR 服务商会让桌宠重新出现：托盘只改变窗口的即时可见状态，而每次保存通用设置都会完整调用 `applyGeneralSettings()`，重新执行仍为 `true` 的持久化 `petVisible` 设置。

保存设置时传入变更前的配置，仅应用实际变化的可见性、置顶、缩放和开机启动选项，避免无关设置覆盖用户临时隐藏/显示的窗口状态。启动时继续完整应用配置；用户明确修改“显示桌宠”时仍正常显示或隐藏。

## 🧪 测试

- `npx vitest run src/main/settings/general-settings-lifecycle.test.ts src/main/application/core-bootstrap.test.ts src/main/settings/launch-at-login.test.ts src/main/tray.test.ts`：4 个文件、23 项测试通过。
- 新增回归覆盖：托盘隐藏后切换 ASR 服务商、临时显示后保存无关设置、显式显示/隐藏、修改置顶/缩放时保持隐藏，以及启动时两种可见性配置。
- `npx tsc --noEmit -p tsconfig.main.json`：通过。
- `git diff --check`：通过。
- 未在真实 Electron 窗口中手动复现；自动化测试通过实际设置变更处理入口验证窗口调用和可见状态，相关启动/托盘测试同时通过。

## ✅ Checklist

- [x] 本 PR 只包含与目标直接相关的改动。
- [x] 已进行必要回归测试及主进程类型检查。
- [x] 已阅读贡献指南；本次是设置应用逻辑的内部修复，不涉及列出的核心模块契约变更。
- [x] 未新增进程、缓存、租约或其他生命周期资源。
- [x] 新增中文注释解释为何区分启动与设置变更。
- [x] 已同步添加回归测试。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 保存通用设置时，仅应用实际发生变化的选项，避免不必要的窗口操作。
  - 修复隐藏状态下保存其他设置时宠物窗口被意外显示的问题。
  - 调整窗口置顶、缩放、开机自启等偏好的应用行为，确保不影响宠物当前可见性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->