### PR TITLE
feat(qq): 新增 SnowLuma 受管接入、独立卡片与黑名单

### DIFF
--- a/docs/snowluma-managed-qq.md
+++ b/docs/snowluma-managed-qq.md
@@ -1,0 +1,66 @@
+# SnowLuma 受管 QQ 接入
+
+## 使用
+
+设置 → 渠道分别显示 QQ（SnowLuma）与 QQ（NapCat）两张卡片，使用教程默认折叠。两者共用唯一 QQ 接入槽，不能同时启用。
+
+SnowLuma 卡片输入机器人 QQ 号后创建实例，会下载官方 Windows x64 完整包，校验固定 SHA-256 后安装。首版固定 v1.14.15，不自动追随上游更新；不在 Cyrene 仓库或安装包内再分发 SnowLuma 二进制。创建时默认关闭自动启动。
+
+SnowLuma 使用用户/群黑名单：
+- 空黑名单默认允许所有私聊；群聊仍必须 @ 机器人。
+- 用户黑名单屏蔽该用户的私聊及群内消息；群黑名单屏蔽整个群。
+- 保存黑名单即时生效，不重启 SL。
+- NapCat 仍使用白名单，空白名单不回复。旧版 SL 白名单不转换成黑名单，也不再限制 SL 消息。
+
+启动时自动为绑定账号写入完整反向 WebSocket 地址 `ws://127.0.0.1:<实例端口>/onebot/v11/ws` 和 Token，无需用户手填。OneBot 端口/Token 在创建时持久化；WebUI 首次分配端口后保存到 runtime.json 并复用，已有首版实例沿用其已保存的端口。端口冲突明确报错，不偷偷换地址或终止其他程序。SL 自身若回退到别的端口，受管启动也会停止并报错。
+
+WebUI 就绪后点击“打开 WebUI”。首次用户名为 admin，凭据保存在实例目录 `snowluma/webui-initial-credentials.txt`，不进入状态 IPC 或普通日志；该文件为敏感明文，改密后应删除。固定 WebUI 地址并不代表永不重新登录，会话有效期由 SL 自身管理。OneBot Token 与 WebUI 登录密码是不同凭据。
+
+在官方 WebUI 阅读并确认协议，再手动选择专用 QQ 进程进行 Hook。Cyrene 不自动同意协议、不自动扫描注入现有 QQ。连接成功不代表 QQ Hook 已正常捕获消息；无回复时检查登录、Hook、黑名单、群 @ 和模型配置，勿用机器人账号给自己发消息。
+
+## 生命周期与数据边界
+
+- 最多一个受管实例，绑定一个机器人 QQ；已有非受管 QQ 渠道需先停用再创建。
+- 握手核对 get_login_info.user_id、绑定账号与 X-Self-ID，入站逐条校验 self_id。这是防止误接入，不是对恶意后端的身份认证。
+- 受管会话历史键包含机器人账号；不把旧非受管历史迁入新账号。旧请求尚未完成时拒绝启动新连接，避免跨账号回包。
+- SL 的 OneBot/WebUI 只监听回环地址；受管模式禁止 UI 修改监听端口和 Token。外部 NapCat 保留原监听模式。
+- 全局 OneBot 配置为禁用连接，只为绑定账号生成启用配置。每次启动关闭自动 Hook，忽略继承的 SNOWLUMA_* 环境变量。
+- “随 Cyrene 启动”还要求 QQ 渠道启用。关闭至托盘不等于退出；真正退出或父进程控制管道断开时，guardian 回收其启动的 SL 进程树，不按名称批量杀进程。
+- 停止 SL 不保证卸载已注入现有 QQ 的 Hook；需要时先在 WebUI 卸载。删除实例也不删除 Cyrene 对话、个人记忆及渠道消息日志。
+- **黑名单默认放行并非多租户权限隔离。** 群聊共享个人记忆但禁用工具；私聊工具权限沿用全局渠道配置。请使用专用机器人并了解此边界。
+
+受管目录为 `app.getPath('userData')/integrations/qq-instance/`：
+
+```text
+instance.json
+snowluma/
+  runtime/                    官方包、config、logs、SL 运行数据
+    cyrene-installation.json  来源、版本、SHA-256
+  environment/                独立 home、temp、appdata、localappdata
+  snowluma-guardian.cjs        应用内复制出的管理入口，兼容 ASAR
+  webui-initial-credentials.txt
+```
+
+安装临时目录也在实例内，正常结束或失败都会清理；强制结束可能留下 staging-*，可随实例清理删除。仅删除绑定并保留数据时，禁止把旧 SL 安装分配给新账号；无实例时仍可勾选清理数据再删除。
+
+与正式版并行开发时应自行配置隔离启动入口，将 userData、缓存、日志、TEMP 指向开发目录；本 PR 不包含个人开发脚本。QQ 客户端、默认外部浏览器和 Windows 自身数据不受此隔离控制，不能承诺整台电脑零写入其他磁盘。Docker 非必需，也不会自动隔离 Windows QQ Hook。
+
+## 验证与首版限制
+
+在隔离 TEMP/npm cache 环境运行：
+
+```powershell
+npx vitest run src/main/channels src/renderer/settings/channels/qq-instance-panel.test.ts
+npm run build
+node scripts/verify/snowluma-smoke.cjs
+```
+
+测试包括实例单例、操作锁、安装失败重试、数据保留/清理、SL 黑名单与 NapCat 白名单、账号隔离、生成的 URL 对接真实 WebSocket 监听器、固定 WebUI 端口及冲突、两张卡片和折叠教程、黑名单免重启保存、guardian 进程回收。smoke 使用假 Node 服务，不启动真实 SL/QQ，验证受管路径、凭据、配置和跨重启地址稳定。
+
+解压使用 yauzl 3.4.0，拒绝路径穿越、Windows 设备名、符号链接和超限包，下载先校验 SHA-256。已核对 SL 1.14.15 OneBot 流接口声明，使用其版本门槛而非 NapCat 的 4.8.115。
+
+真实 QQ/Hook 的文字、图片、语音、大文件完整收发与安装包 E2E 仍待验收。首版没有自动升级、回滚、实例导入或自动卸载 Hook。
+
+不复制 MoFox AGPL 代码；仅参考其受管安装与生命周期交互。个人数据、凭据、SL 二进制和开发绝对路径不可提交。公开发行前仍需确认 SnowLuma 许可及上游接入政策。
+
+参考：[SnowLuma v1.14.15](https://github.com/SnowLuma/SnowLuma/releases/tag/v1.14.15)、[yauzl](https://github.com/thejoshwolfe/yauzl)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
         "vscode-languageserver-types": "^3.18.0",
         "wink-bm25-text-search": "^3.1.2",
         "ws": "^8.21.0",
-        "yaml": "^2.9.0"
+        "yaml": "^2.9.0",
+        "yauzl": "3.4.0"
       },
       "bin": {
         "cyrene": "dist/cli/index.js"
@@ -83,6 +84,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/turndown": "^5.0.6",
+        "@types/yauzl": "^3.4.0",
         "@vitejs/plugin-react": "^4.7.0",
         "concurrently": "^9.2.1",
         "cross-env": "^7.0.3",
@@ -5906,11 +5908,11 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -9824,6 +9826,26 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/extract-zip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/fast-csv": {
@@ -17370,13 +17392,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/turndown": "^5.0.6",
+    "@types/yauzl": "^3.4.0",
     "@vitejs/plugin-react": "^4.7.0",
     "concurrently": "^9.2.1",
     "cross-env": "^7.0.3",
@@ -125,7 +126,8 @@
     "vscode-languageserver-types": "^3.18.0",
     "wink-bm25-text-search": "^3.1.2",
     "ws": "^8.21.0",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "yauzl": "3.4.0"
   },
   "allowScripts": {
     "protobufjs@7.6.4": true,

--- a/scripts/verify/snowluma-smoke.cjs
+++ b/scripts/verify/snowluma-smoke.cjs
@@ -1,0 +1,46 @@
+// Build main first. Tests the actual supervisor against a fake runtime, never QQ.
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { SnowLumaRuntime } = require('../../dist/main/main/channels/snowluma-runtime.js');
+
+(async () => {
+  if (process.platform !== 'win32') throw new Error('Windows-only smoke');
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cyrene-sl-smoke-'));
+  const cwd = path.join(root, 'runtime');
+  const runtime = new SnowLumaRuntime(root, () => {});
+  try {
+    await fs.mkdir(cwd);
+    await fs.copyFile(process.execPath, path.join(cwd, 'node.exe'));
+    await fs.writeFile(path.join(cwd, 'index.mjs'), `
+      import fs from 'node:fs';
+      fs.writeFileSync('smoke.json', JSON.stringify({pid: process.pid, home: process.env.USERPROFILE, temp: process.env.TEMP, logs: process.env.SNOWLUMA_LOG_DIR, hook: process.env.SNOWLUMA_HOOK_AUTOLOAD}));
+      console.log('initial credentials: user=admin password=0123456789abcdef');
+      console.log('listening http://127.0.0.1:' + process.env.SNOWLUMA_WEBUI_PORT);
+      setInterval(() => {}, 1000);
+    `);
+    await runtime.start('123456', 16200, 'fake-token');
+    assert.match(runtime.webuiUrl, /^http:\/\/127\.0\.0\.1:\d+\/$/);
+    const state = JSON.parse(await fs.readFile(path.join(cwd, 'smoke.json'), 'utf8'));
+    for (const key of ['home', 'temp', 'logs']) assert.ok(state[key].startsWith(root + path.sep));
+    assert.equal(state.hook, '0');
+    const globalConfig = JSON.parse(await fs.readFile(path.join(cwd, 'config/onebot.json'), 'utf8'));
+    assert.equal(globalConfig.networks.wsClients[0].enabled, false);
+    const accountConfig = JSON.parse(await fs.readFile(path.join(cwd, 'config/onebot_123456.json'), 'utf8'));
+    assert.equal(accountConfig.networks.wsClients[0].accessToken, 'fake-token');
+    assert.equal(accountConfig.networks.wsClients[0].url, 'ws://127.0.0.1:16200/onebot/v11/ws');
+    assert.match(await fs.readFile(path.join(root, 'webui-initial-credentials.txt'), 'utf8'), /Username: admin/);
+    const firstUrl = runtime.webuiUrl;
+    await runtime.stop();
+    assert.throws(() => process.kill(state.pid, 0));
+    assert.equal(runtime.webuiUrl, undefined);
+    await runtime.start('123456', 16200, 'fake-token');
+    assert.equal(runtime.webuiUrl, firstUrl);
+    await runtime.stop();
+    console.log('SNOWLUMA_SMOKE_OK: paths, config, credentials, supervisor shutdown; no QQ loaded');
+  } finally {
+    await runtime.stop();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+})().catch(error => { console.error(error); process.exitCode = 1; });

--- a/src/main/channels/adapters/qq/napcat-adapter.integration.test.ts
+++ b/src/main/channels/adapters/qq/napcat-adapter.integration.test.ts
@@ -26,6 +26,13 @@ const mockedSettings = vi.hoisted(() => ({
   toolSandbox: "all" as const,
 }));
 
+const managed = vi.hoisted(() => ({ instance: null as null | { backend: "snowluma"; accountId: string; autoStart: boolean }, start: vi.fn(), stop: vi.fn() }));
+vi.mock("../../qq-instance", () => ({
+  readQqInstance: () => managed.instance,
+  getSnowLumaRuntime: () => ({ start: managed.start, stop: managed.stop }),
+  setQqInstancePhase: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
   app: { getPath: () => process.env.TEMP ?? process.cwd() },
 }));
@@ -36,6 +43,7 @@ vi.mock("../../settings-store", async (importOriginal) => {
 });
 
 import { NapCatAdapter } from "./napcat-adapter";
+import { buildSnowLumaConfig } from "../../snowluma-runtime";
 
 const sockets: WebSocket[] = [];
 const adapters: NapCatAdapter[] = [];
@@ -43,6 +51,8 @@ const adapters: NapCatAdapter[] = [];
 afterEach(async () => {
   for (const socket of sockets.splice(0)) socket.terminate();
   for (const adapter of adapters.splice(0)) await adapter.stop();
+  managed.instance = null;
+  managed.start.mockClear();
 });
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
@@ -54,6 +64,47 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<voi
 }
 
 describe("NapCatAdapter fake reverse WebSocket integration", () => {
+  it("does not autostart a managed instance unless explicitly requested", async () => {
+    managed.instance = { backend: "snowluma", accountId: "123456", autoStart: false };
+    const adapter = new NapCatAdapter(); adapters.push(adapter);
+    await adapter.start();
+    expect(managed.start).not.toHaveBeenCalled();
+    await adapter.start(true);
+    expect(managed.start).toHaveBeenCalledWith("123456", expect.any(Number), "");
+    expect(managed.start.mock.calls[0][1]).toBeGreaterThan(0);
+  });
+
+  it.each(["123456", "999999"])("checks bound SL account during handshake (%s)", async (loginId) => {
+    managed.instance = { backend: "snowluma", accountId: "123456", autoStart: true };
+    const adapter = new NapCatAdapter(); adapters.push(adapter);
+    await adapter.start();
+    // Exercise the generated SL URL against the real listener, not a duplicated test URL.
+    const port = Number(new URL(String(adapter.getConnectionInfo().listenUrl)).port);
+    const url = buildSnowLumaConfig("123456", port, "test-token").networks.wsClients[0].url;
+    const socket = new WebSocket(url, { headers: { "X-Self-ID": loginId } });
+    sockets.push(socket);
+    socket.on("message", raw => {
+      const request = JSON.parse(raw.toString());
+      socket.send(JSON.stringify({ status: "ok", retcode: 0, echo: request.echo,
+        data: request.action === "get_login_info" ? { user_id: loginId } : { app_name: "SnowLuma", app_version: "1.14.15" },
+      }));
+    });
+    if (loginId !== "123456") {
+      await new Promise<void>(resolve => socket.once("close", () => resolve()));
+      expect(adapter.getConnectionInfo().selfId).toBeFalsy();
+    } else {
+      await waitFor(() => adapter.getStatus().phase === "running");
+      expect(adapter.getConnectionInfo()).toMatchObject({ selfId: "123456", supportsStream: true });
+      const received: IncomingMessage[] = [];
+      adapter.onMessage = async message => { received.push(message); return null; };
+      // This sender is not in NapCat's allowlist, but SL's empty denylist permits it.
+      socket.send(JSON.stringify({ post_type: "message", message_type: "private", self_id: loginId,
+        user_id: "1002", message_id: "sl-message", time: 1, message: [{ type: "text", data: { text: "test" } }] }));
+      await waitFor(() => received.length === 1);
+      expect(received[0].accountId).toBe("123456");
+    }
+  });
+
   it("handshakes, filters events, deduplicates, and sends private/group replies", async () => {
     const adapter = new NapCatAdapter();
     adapters.push(adapter);

--- a/src/main/channels/adapters/qq/napcat-adapter.test.ts
+++ b/src/main/channels/adapters/qq/napcat-adapter.test.ts
@@ -18,6 +18,18 @@ const config: QqChannelConfig = {
 };
 
 describe("NapCatAdapter policy helpers", () => {
+  it("uses deny lists only for SL, including blocked users in groups", () => {
+    const cfg = { ...config, allowedPrivateUserIds: [], allowedGroupIds: [], blockedUserIds: ["1001"], blockedGroupIds: ["2001"] };
+    const privateMsg = { message_type: "private" as const, user_id: "1000", message: [] };
+    expect(isQqEventAllowed(privateMsg, cfg, "9000", "blocklist")).toBe(true);
+    expect(isQqEventAllowed(privateMsg, cfg, "9000")).toBe(false);
+    expect(isQqEventAllowed({ ...privateMsg, user_id: "1001" }, cfg, "9000", "blocklist")).toBe(false);
+    const groupMsg = { ...privateMsg, message_type: "group" as const, group_id: "2000", message: [{ type: "at" as const, data: { qq: "9000" } }] };
+    expect(isQqEventAllowed(groupMsg, cfg, "9000", "blocklist")).toBe(true);
+    expect(isQqEventAllowed({ ...groupMsg, user_id: "1001" }, cfg, "9000", "blocklist")).toBe(false);
+    expect(isQqEventAllowed({ ...groupMsg, group_id: "2001" }, cfg, "9000", "blocklist")).toBe(false);
+    expect(isQqEventAllowed({ ...groupMsg, message: [] }, cfg, "9000", "blocklist")).toBe(false);
+  });
   it("requires private allowlist and group allowlist plus bot mention", () => {
     expect(isQqEventAllowed({ message_type: "private", user_id: "1000", message: [] }, config, "9000")).toBe(true);
     expect(isQqEventAllowed({ message_type: "private", user_id: "1001", message: [] }, config, "9000")).toBe(false);

--- a/src/main/channels/adapters/qq/napcat-adapter.ts
+++ b/src/main/channels/adapters/qq/napcat-adapter.ts
@@ -21,6 +21,7 @@ import {
   type OneBotVersionInfo,
 } from "./onebot-types";
 import type { QqChannelConfig } from "../../settings-store";
+import { readQqInstance, getSnowLumaRuntime, setQqInstancePhase } from "../../qq-instance";
 
 const CAPABILITY: ChannelCapability = {
   text: true,
@@ -64,11 +65,13 @@ export function isQqEventAllowed(
   event: { message_type: "private" | "group"; user_id: string | number; group_id?: string | number; message: OneBotSegment[] },
   config: QqChannelConfig,
   selfId: string,
+  policy: "allowlist" | "blocklist" = "allowlist",
 ): boolean {
   const senderId = oneBotId(event.user_id);
-  if (event.message_type === "private") return config.allowedPrivateUserIds.includes(senderId);
+  if (policy === "blocklist" && config.blockedUserIds?.includes(senderId)) return false;
+  if (event.message_type === "private") return policy === "blocklist" || config.allowedPrivateUserIds.includes(senderId);
   const groupId = oneBotId(event.group_id);
-  if (!config.allowedGroupIds.includes(groupId)) return false;
+  if (policy === "blocklist" ? config.blockedGroupIds?.includes(groupId) : !config.allowedGroupIds.includes(groupId)) return false;
   return !config.groupRequireMention || event.message.some((segment) =>
     segment.type === "at" && oneBotId(segment.data.qq) === selfId,
   );
@@ -80,7 +83,7 @@ function delay(ms: number): Promise<void> {
 
 export class NapCatAdapter implements ChannelAdapter {
   readonly id = "qq" as const;
-  readonly displayName = "QQ（NapCat）";
+  get displayName(): string { return readQqInstance()?.backend === "snowluma" ? "QQ（SnowLuma）" : "QQ（NapCat）"; }
   readonly capability = CAPABILITY;
   onMessage: MessageHandler | null = null;
 
@@ -102,19 +105,23 @@ export class NapCatAdapter implements ChannelAdapter {
   private supportsStream = false;
   private listeningInfo: OneBotListeningInfo | null = null;
   private dedupe = new Map<string, number>();
+  private inFlight = 0;
 
   constructor(private readonly onStatusChanged?: () => void) {}
 
-  async start(): Promise<void> {
+  async start(manual = false): Promise<void> {
+    if (this.inFlight) throw new Error("旧 QQ 请求尚未结束，请稍后启动，避免跨账号发送");
+    if (this.server) return;
+    const instance = readQqInstance();
     const config = loadChannelsSettings().qq;
-    if (!config.enabled) {
+    if (!config.enabled || (instance && !manual && !instance.autoStart)) {
       this.setStatus({ enabled: false, phase: "offline", message: "未启用" });
       return;
     }
     this.setStatus({ enabled: true, phase: "starting", message: "正在启动 OneBot 监听" });
     await this.media.start();
     this.server = new OneBotReverseWsServer({
-      listenMode: config.listenMode,
+      listenMode: instance?.backend === "snowluma" ? "loopback" : config.listenMode,
       customHost: config.customHost,
       port: config.port,
       accessToken: config.accessToken,
@@ -123,10 +130,11 @@ export class NapCatAdapter implements ChannelAdapter {
       onClientDisconnected: () => {
         this.client = null;
         this.selfId = "";
+        if (instance) setQqInstancePhase("starting", "绑定 QQ 已断开，等待重连；请检查 SL/NapCat 的登录和 Hook 状态");
         this.setStatus({
           enabled: true,
           phase: "starting",
-          message: "监听中，等待 NapCat 重连",
+          message: `监听中，等待 ${this.displayName} 重连`,
           detail: this.statusDetail(),
         });
       },
@@ -141,13 +149,23 @@ export class NapCatAdapter implements ChannelAdapter {
     });
     try {
       this.listeningInfo = await this.server.start();
-      this.setStatus({
-        enabled: true,
-        phase: "starting",
-        message: "监听中，等待 NapCat 连接",
-        detail: this.statusDetail(),
-      });
+      if (instance?.backend === "snowluma") {
+        setQqInstancePhase("starting", "正在启动 SnowLuma");
+        await getSnowLumaRuntime().start(instance.accountId, this.listeningInfo.port, config.accessToken ?? "");
+      }
+      // The backend can complete its OneBot handshake before WebUI startup returns.
+      if (!this.selfId) {
+        if (instance) setQqInstancePhase("running", "实例已启动，等待绑定 QQ 连接");
+        this.setStatus({
+          enabled: true,
+          phase: "starting",
+          message: `监听中，等待 ${this.displayName} 连接`,
+          detail: this.statusDetail(),
+        });
+      }
     } catch (error) {
+      await this.server?.stop();
+      await getSnowLumaRuntime().stop();
       this.media.stop();
       this.server = null;
       const message = error instanceof Error ? error.message : String(error);
@@ -167,6 +185,8 @@ export class NapCatAdapter implements ChannelAdapter {
     this.supportsStream = false;
     this.listeningInfo = null;
     this.dedupe.clear();
+    await getSnowLumaRuntime().stop();
+    setQqInstancePhase("stopped", "已停止");
     this.setStatus({ enabled: false, phase: "offline", message: "已停止" });
   }
 
@@ -240,22 +260,28 @@ export class NapCatAdapter implements ChannelAdapter {
     const login = await client.call<OneBotLoginInfo>("get_login_info");
     const version = await client.call<OneBotVersionInfo>("get_version_info");
     const selfId = oneBotId(login.user_id);
+    const instance = readQqInstance();
+    if (instance && selfId !== instance.accountId) throw new Error("连接的 QQ 与实例绑定账号不一致，已拒绝接入");
     if (!selfId) throw new Error("NapCat get_login_info 未返回 user_id");
     if (headerSelfId && headerSelfId !== selfId) throw new Error("NapCat X-Self-ID 与 get_login_info 不一致");
     this.client = client;
     this.selfId = selfId;
     this.nickname = login.nickname ?? "";
     this.appVersion = version.app_version ?? "";
-    this.supportsStream = versionAtLeast(this.appVersion, ONEBOT_STREAM_MIN_VERSION);
+    this.supportsStream = instance?.backend === "snowluma"
+      ? /snowluma/i.test(version.app_name ?? "") && versionAtLeast(this.appVersion, "1.14.15")
+      : versionAtLeast(this.appVersion, ONEBOT_STREAM_MIN_VERSION);
+    if (instance) setQqInstancePhase("running", `${this.displayName} 已连接绑定账号`);
     this.setStatus({
       enabled: true,
       phase: "running",
-      message: this.supportsStream ? "NapCat 已连接" : `NapCat 已连接；媒体流需要 ${ONEBOT_STREAM_MIN_VERSION}+`,
+      message: `${this.displayName} 已连接${this.supportsStream ? "" : "；媒体流不可用"}`,
       detail: this.statusDetail(),
     });
   }
 
   private async handleEvent(event: OneBotEvent, client: OneBotActionClient): Promise<void> {
+    if (client !== this.client) return;
     if (!isOneBotMessageEvent(event) || event.post_type !== "message") return;
     if (!this.selfId || oneBotId(event.self_id) !== this.selfId || oneBotId(event.user_id) === this.selfId) return;
 
@@ -263,7 +289,8 @@ export class NapCatAdapter implements ChannelAdapter {
     const senderId = oneBotId(event.user_id);
     const chatId = event.message_type === "group" ? oneBotId(event.group_id) : senderId;
     if (!chatId) return;
-    if (!isQqEventAllowed(event, config, this.selfId)) return;
+    const instance = readQqInstance();
+    if (!isQqEventAllowed(event, config, this.selfId, instance?.backend === "snowluma" ? "blocklist" : "allowlist")) return;
 
     const dedupeKey = `${this.selfId}:${oneBotId(event.message_id)}`;
     const now = Date.now();
@@ -271,17 +298,20 @@ export class NapCatAdapter implements ChannelAdapter {
     if (this.dedupe.has(dedupeKey)) return;
     this.dedupe.set(dedupeKey, now + DEDUPE_TTL_MS);
 
+    const accountId = instance?.accountId;
     try {
+      this.inFlight++;
       const incoming = await normalizeOneBotMessage(event, {
         selfId: this.selfId,
         client,
         media: this.media,
         supportsStream: this.supportsStream,
       });
+      incoming.accountId = accountId;
       await this.onMessage?.(incoming);
     } catch (error) {
       console.warn("[NapCatAdapter] QQ 消息处理失败:", error instanceof Error ? error.message : String(error));
-    }
+    } finally { this.inFlight--; }
   }
 
   private async partToPayloads(part: OutgoingPart): Promise<OneBotSegment[][]> {

--- a/src/main/channels/adapters/qq/napcat-adapter.ts
+++ b/src/main/channels/adapters/qq/napcat-adapter.ts
@@ -22,6 +22,7 @@ import {
 } from "./onebot-types";
 import type { QqChannelConfig } from "../../settings-store";
 import { readQqInstance, getSnowLumaRuntime, setQqInstancePhase } from "../../qq-instance";
+import { SNOWLUMA_VERSION } from "../../snowluma-runtime";
 
 const CAPABILITY: ChannelCapability = {
   text: true,
@@ -94,7 +95,7 @@ export class NapCatAdapter implements ChannelAdapter {
     this.setStatus({
       enabled: true,
       phase: "running",
-      message: `NapCat Stream API 不可用；请升级到 ${ONEBOT_STREAM_MIN_VERSION}+`,
+      message: `${this.displayName} Stream API 不可用；请升级到 ${this.streamMinVersion()}+`,
       detail: this.statusDetail(),
     });
   });
@@ -201,7 +202,7 @@ export class NapCatAdapter implements ChannelAdapter {
   }
 
   async testConnection(): Promise<{ ok: boolean; error?: string; detail?: Record<string, unknown> }> {
-    if (!this.client || !this.selfId) return { ok: false, error: "NapCat 尚未连接" };
+    if (!this.client || !this.selfId) return { ok: false, error: `${this.displayName} 尚未连接` };
     try {
       const status = await this.client.call<Record<string, unknown>>("get_status");
       return { ok: true, detail: { ...this.statusDetail(), protocolStatus: status } };
@@ -212,7 +213,7 @@ export class NapCatAdapter implements ChannelAdapter {
 
   async send(msg: OutgoingMessage): Promise<{ ok: boolean; error?: string }> {
     const client = this.client;
-    if (!client || !this.selfId) return { ok: false, error: "NapCat 未连接" };
+    if (!client || !this.selfId) return { ok: false, error: `${this.displayName} 未连接` };
     const payloads: OneBotSegment[][] = [];
     let lastError: string | undefined;
 
@@ -269,7 +270,7 @@ export class NapCatAdapter implements ChannelAdapter {
     this.nickname = login.nickname ?? "";
     this.appVersion = version.app_version ?? "";
     this.supportsStream = instance?.backend === "snowluma"
-      ? /snowluma/i.test(version.app_name ?? "") && versionAtLeast(this.appVersion, "1.14.15")
+      ? /snowluma/i.test(version.app_name ?? "") && versionAtLeast(this.appVersion, SNOWLUMA_VERSION)
       : versionAtLeast(this.appVersion, ONEBOT_STREAM_MIN_VERSION);
     if (instance) setQqInstancePhase("running", `${this.displayName} 已连接绑定账号`);
     this.setStatus({
@@ -356,8 +357,13 @@ export class NapCatAdapter implements ChannelAdapter {
       nickname: this.nickname || undefined,
       appVersion: this.appVersion || undefined,
       supportsStream: this.supportsStream,
-      streamMinimumVersion: ONEBOT_STREAM_MIN_VERSION,
+      streamMinimumVersion: this.streamMinVersion(),
     };
+  }
+
+  /** SnowLuma 与 NapCat 的媒体流版本门槛不同，状态上报需与 supportsStream 判断一致。 */
+  private streamMinVersion(): string {
+    return readQqInstance()?.backend === "snowluma" ? SNOWLUMA_VERSION : ONEBOT_STREAM_MIN_VERSION;
   }
 
   private setStatus(status: ChannelStatus): void {

--- a/src/main/channels/channel-context.ts
+++ b/src/main/channels/channel-context.ts
@@ -134,6 +134,12 @@ export function createChannelContext(
     },
 
     recordIncomingSession(msg, context): void {
+      // 受管实例启用后历史键带账号；老用户升级前是无账号键，先一次性迁过来
+      // （migrateHistory 幂等：目标存在即跳过，copy 不删源）。
+      if (msg.accountId) {
+        options.migrateHistory(makeSessionId(msg.channel, msg.chatId), context.sessionId);
+        options.migrateHistory(makeSessionId(msg.channel, msg.senderId), context.sessionId);
+      }
       options.migrateHistory(
         makeSessionId(msg.channel, msg.senderId, msg.accountId),
         context.sessionId,

--- a/src/main/channels/channel-context.ts
+++ b/src/main/channels/channel-context.ts
@@ -80,9 +80,10 @@ const sessionIndex = new Map<
 >();
 
 /** 计算稳定且匿名的渠道会话标识。 */
-export function makeSessionId(channel: ChannelId, chatId: string): string {
+export function makeSessionId(channel: ChannelId, chatId: string, account?: string): string {
+  // Managed accounts have separate histories; legacy installations retain their keys.
   const hash = createHash("sha256")
-    .update(`${channel}:${chatId}`)
+    .update(account ? `${channel}:${account}:${chatId}` : `${channel}:${chatId}`)
     .digest("hex")
     .slice(0, 16);
   return `channel:${channel}:${hash}`;
@@ -134,7 +135,7 @@ export function createChannelContext(
 
     recordIncomingSession(msg, context): void {
       options.migrateHistory(
-        makeSessionId(msg.channel, msg.senderId),
+        makeSessionId(msg.channel, msg.senderId, msg.accountId),
         context.sessionId,
       );
       recordSession(msg.channel, msg.senderId, context.sessionId);

--- a/src/main/channels/dispatcher.ts
+++ b/src/main/channels/dispatcher.ts
@@ -111,7 +111,7 @@ export class ChannelDispatcher {
    * 返回的出站消息仅供调用方观测和测试，不要求适配器再次发送。
    */
   async handleIncoming(msg: IncomingMessage): Promise<OutgoingMessage | null> {
-    const sessionId = makeSessionId(msg.channel, msg.chatId);
+    const sessionId = makeSessionId(msg.channel, msg.chatId, msg.accountId);
     // 读取设置会同步刷新限速器，必须发生在本轮额度消费之前。
     void this.settings;
     return this.deps.queue.run(`external:${sessionId}`, async () => {

--- a/src/main/channels/init.ts
+++ b/src/main/channels/init.ts
@@ -214,14 +214,27 @@ function registerChannelsIpc(
     });
   });
 
-  ipc.handle(IPC.CHANNELS_SAVE_CONFIG, (_e, patch: unknown) => {
+  ipc.handle(IPC.CHANNELS_SAVE_CONFIG, async (_e, patch: unknown) => {
     const incoming = patch as { qq?: Record<string, unknown> };
+    const qqEnabledBefore = incoming?.qq && typeof incoming.qq.enabled === "boolean"
+      ? loadChannelsSettings().qq.enabled : undefined;
     if (incoming?.qq && readQqInstance()?.backend === "snowluma") {
       const current = loadChannelsSettings().qq;
       incoming.qq = { ...incoming.qq, port: current.port, listenMode: "loopback", accessToken: current.accessToken };
     }
     saveChannelsSettings(patch as Parameters<typeof saveChannelsSettings>[0]);
     reloadDispatcherSettings();
+    // 自动保存不经过实例面板：enabled 状态转换时复用手动保存的 stop/restart 生命周期，
+    // 否则运行中的 SnowLuma 会在 enabled=false 落盘后继续运行。
+    if (qqEnabledBefore !== undefined && incoming.qq && incoming.qq.enabled !== qqEnabledBefore && qqAdapter) {
+      try {
+        await qqAdapter.stop();
+        if (incoming.qq.enabled) await qqAdapter.start(true);
+      } catch (error) {
+        console.warn("[channels] QQ enabled 切换未完全生效:", error instanceof Error ? error.message : error);
+      }
+      broadcastChannelsStatus();
+    }
     return getPublicChannelsSettings();
   });
 

--- a/src/main/channels/init.ts
+++ b/src/main/channels/init.ts
@@ -9,7 +9,9 @@
 //   - shutdownChannels()：停 adapter + inbound-server，并复位两个 flag
 //
 // 注意：startChannels 必须晚于 initRAG / initMcpManager / loadModelSettings。
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, shell } from "electron";
+import type { QqInstanceRequest } from "../../shared/qq-instance";
+import { readQqInstance, qqInstanceStatus, withQqInstanceOperation, createQqInstance, configureQqInstance, deleteQqInstance } from "./qq-instance";
 import { IPC } from "../../shared/ipc-channels";
 import { createIpcScope, type IpcScope } from "../application/ipc-scope";
 import {
@@ -145,6 +147,8 @@ export async function startChannels(signal?: AbortSignal): Promise<void> {
 /** app.on('before-quit') 调 */
 export async function shutdownChannels(): Promise<void> {
   await channelManager.stopAll();
+  // Manual starts may not be in the manager's startAll bookkeeping.
+  await qqAdapter?.stop();
   await stopInboundServer();
   initialized = false;
   started = false;
@@ -158,7 +162,64 @@ function registerChannelsIpc(
   const ipc = ipcOption ?? createIpcScope();
   ipc.handle(IPC.CHANNELS_GET_CONFIG, () => getPublicChannelsSettings());
 
+  ipc.handle(IPC.CHANNELS_QQ_INSTANCE, async (_e, request: QqInstanceRequest) => {
+    if (!request || typeof request.action !== "string") throw new Error("无效实例操作");
+    if (request.action === "status") return qqInstanceStatus();
+    return withQqInstanceOperation(async () => {
+      if (!qqAdapter) throw new Error("QQ adapter 未初始化");
+      let instance: ReturnType<typeof readQqInstance>;
+      try { instance = readQqInstance(); }
+      catch (error) {
+        // Allow explicit cleanup of a corrupted manifest, but never skip backend
+        // ownership checks for a valid instance when another settings window is stale.
+        if (request.action !== "delete") throw error;
+        instance = null;
+      }
+      if (instance && request.backend && request.backend !== instance.backend) throw new Error("另一 QQ 后端已占用该实例，请刷新后重试");
+      switch (request.action) {
+        case "create":
+          if (instance) throw new Error("只允许一个 QQ 实例，请先删除现有实例");
+          if (loadChannelsSettings().qq.enabled) throw new Error("请先停止现有 QQ 渠道");
+          await qqAdapter.stop();
+          await createQqInstance(request);
+          break;
+        case "configure": configureQqInstance(request.autoStart === true); break;
+        case "start":
+        case "restart": {
+          if (!instance) throw new Error("请先创建 QQ 实例");
+          await qqAdapter.stop();
+          const qq = loadChannelsSettings().qq;
+          saveChannelsSettings({ qq: { ...qq, enabled: true } });
+          await qqAdapter.start(true);
+          break;
+        }
+        case "stop":
+        case "delete": {
+          await qqAdapter.stop();
+          saveChannelsSettings({ qq: { ...loadChannelsSettings().qq, enabled: false } });
+          if (request.action === "delete") await deleteQqInstance(request.removeData === true);
+          break;
+        }
+        case "open": {
+          const url = qqInstanceStatus().webuiUrl;
+          if (!url || !/^http:\/\/127\.0\.0\.1:\d+\/$/.test(url)) throw new Error("WebUI 尚未就绪");
+          await shell.openExternal(url);
+          break;
+        }
+        default: throw new Error("不支持的 QQ 实例操作");
+      }
+      reloadDispatcherSettings();
+      broadcastChannelsStatus();
+      return qqInstanceStatus();
+    });
+  });
+
   ipc.handle(IPC.CHANNELS_SAVE_CONFIG, (_e, patch: unknown) => {
+    const incoming = patch as { qq?: Record<string, unknown> };
+    if (incoming?.qq && readQqInstance()?.backend === "snowluma") {
+      const current = loadChannelsSettings().qq;
+      incoming.qq = { ...incoming.qq, port: current.port, listenMode: "loopback", accessToken: current.accessToken };
+    }
     saveChannelsSettings(patch as Parameters<typeof saveChannelsSettings>[0]);
     reloadDispatcherSettings();
     return getPublicChannelsSettings();
@@ -168,12 +229,16 @@ function registerChannelsIpc(
 
   ipc.handle(IPC.CHANNELS_GET_STATUS, () => channelManager.getAllStatus());
 
-  ipc.handle(IPC.CHANNELS_RESTART, async () => {
+  ipc.handle(IPC.CHANNELS_RESTART, () => withQqInstanceOperation(async () => {
+    const instance = readQqInstance();
+    const qqPhase = qqAdapter?.getStatus().phase;
+    const resumeManual = instance && !instance.autoStart && (qqPhase === "running" || qqPhase === "starting");
     await channelManager.stopAll();
     await channelManager.startAll();
+    if (resumeManual) await qqAdapter?.start(true);
     broadcastChannelsStatus();
     return { ok: true };
-  });
+  }));
 
   // ── 微信 IPC (iLink 直连版) ───────────────────────────────────────────────────────
 

--- a/src/main/channels/qq-instance.test.ts
+++ b/src/main/channels/qq-instance.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const state = vi.hoisted(() => ({ root: "", qq: {} as Record<string, unknown>, install: vi.fn(), stop: vi.fn() }));
+vi.mock("electron", () => ({ app: { getPath: () => state.root } }));
+vi.mock("./settings-store", () => ({
+  loadChannelsSettings: () => ({ qq: state.qq }),
+  saveChannelsSettings: (config: { qq: Record<string, unknown> }) => { state.qq = config.qq; },
+}));
+vi.mock("./snowluma-runtime", () => ({
+  SNOWLUMA_VERSION: "test", freeLoopbackPort: async () => 16321,
+  SnowLumaRuntime: class { install = state.install; stop = state.stop; },
+}));
+
+beforeEach(async () => {
+  vi.resetModules();
+  state.root = await fs.mkdtemp(path.join(os.tmpdir(), "cyrene-instance-test-"));
+  state.qq = { enabled: false, allowedPrivateUserIds: ["old"], allowedGroupIds: ["old"] };
+  state.install.mockReset().mockResolvedValue(undefined);
+  state.stop.mockReset().mockResolvedValue(undefined);
+});
+afterEach(async () => { await fs.rm(state.root, { recursive: true, force: true }); });
+
+describe("single managed QQ instance", () => {
+  it("installs once, resets allowlists and rejects a second account", async () => {
+    const api = await import("./qq-instance");
+    await api.createQqInstance({ action: "create", backend: "snowluma", accountId: "123456" });
+    expect(state.install).toHaveBeenCalledTimes(1);
+    expect(api.readQqInstance()).toEqual({ backend: "snowluma", accountId: "123456", autoStart: false });
+    expect(state.qq).toMatchObject({ enabled: false, listenMode: "loopback", allowedGroupIds: [], allowedPrivateUserIds: [], groupRequireMention: true });
+    expect(state.qq.accessToken).toMatch(/^[a-f0-9]{64}$/);
+    await expect(api.createQqInstance({ action: "create", backend: "snowluma", accountId: "234567" })).rejects.toThrow("只允许一个");
+    api.configureQqInstance(true);
+    expect(api.readQqInstance()?.autoStart).toBe(true);
+  });
+  it("leaves no manifest on download failure and allows a retry", async () => {
+    const api = await import("./qq-instance");
+    state.install.mockRejectedValueOnce(new Error("download failed"));
+    const request = { action: "create", backend: "snowluma", accountId: "123456" } as const;
+    await expect(api.withQqInstanceOperation(() => api.createQqInstance(request))).rejects.toThrow("download failed");
+    expect(api.readQqInstance()).toBeNull();
+    await api.withQqInstanceOperation(() => api.createQqInstance(request));
+    expect(api.readQqInstance()?.accountId).toBe("123456");
+  });
+  it("blocks concurrent operations, then releases the lock", async () => {
+    const api = await import("./qq-instance");
+    let release!: () => void;
+    const first = api.withQqInstanceOperation(() => new Promise<void>(resolve => { release = resolve; }));
+    await expect(api.withQqInstanceOperation(async () => {})).rejects.toThrow("进行中");
+    release(); await first;
+    await expect(api.withQqInstanceOperation(async () => "ok")).resolves.toBe("ok");
+  });
+  it("retains data on delete and can explicitly clear it without a manifest", async () => {
+    const api = await import("./qq-instance");
+    await api.createQqInstance({ action: "create", backend: "snowluma", accountId: "123456" });
+    const runtime = path.join(api.qqInstanceRoot(), "snowluma", "runtime");
+    await fs.mkdir(runtime, { recursive: true });
+    await fs.writeFile(path.join(runtime, "sentinel"), "owned");
+    await api.deleteQqInstance(false);
+    expect(api.readQqInstance()).toBeNull();
+    expect(await fs.readFile(path.join(runtime, "sentinel"), "utf8")).toBe("owned");
+    await expect(api.createQqInstance({ action: "create", backend: "snowluma", accountId: "234567" })).rejects.toThrow("保留");
+    await api.deleteQqInstance(true);
+    await expect(fs.access(runtime)).rejects.toThrow();
+  });
+});

--- a/src/main/channels/qq-instance.ts
+++ b/src/main/channels/qq-instance.ts
@@ -1,0 +1,82 @@
+import { app } from "electron";
+import * as fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import type { QqInstance, QqInstanceRequest, QqInstanceStatus } from "../../shared/qq-instance";
+import { SnowLumaRuntime, SNOWLUMA_VERSION, freeLoopbackPort } from "./snowluma-runtime";
+import { loadChannelsSettings, saveChannelsSettings } from "./settings-store";
+import { ONEBOT_WS_PATH } from "./adapters/qq/onebot-reverse-ws";
+
+let runtime: SnowLumaRuntime | undefined;
+let phase: QqInstanceStatus["phase"] = "stopped";
+let message = "已停止";
+let busy = false;
+export const qqInstanceRoot = () => path.join(app.getPath("userData"), "integrations", "qq-instance");
+const manifest = () => path.join(qqInstanceRoot(), "instance.json");
+export function readQqInstance(): QqInstance | null {
+  if (!fs.existsSync(manifest())) return null;
+  const value = JSON.parse(fs.readFileSync(manifest(), "utf8"));
+  if (!value || !["snowluma", "napcat"].includes(value.backend) || !/^[1-9]\d{4,9}$/.test(value.accountId)) {
+    throw new Error("QQ 实例配置损坏，请检查实例目录");
+  }
+  return { backend: value.backend, accountId: value.accountId, autoStart: value.autoStart === true };
+}
+export function getSnowLumaRuntime(): SnowLumaRuntime {
+  return runtime ??= new SnowLumaRuntime(path.join(qqInstanceRoot(), "snowluma"), (msg, failed) => {
+    message = msg;
+    if (failed) phase = "error";
+  });
+}
+export function setQqInstancePhase(value: QqInstanceStatus["phase"], text: string): void { phase = value; message = text; }
+export function qqInstanceStatus(): QqInstanceStatus {
+  const instance = readQqInstance();
+  return { instance, phase: busy && phase === "installing" ? phase : instance ? phase : "absent", message,
+    webuiUrl: runtime?.webuiUrl,
+    onebotUrl: instance?.backend === "snowluma" ? `ws://127.0.0.1:${loadChannelsSettings().qq.port}${ONEBOT_WS_PATH}` : undefined,
+    root: qqInstanceRoot(), version: instance?.backend === "snowluma" ? SNOWLUMA_VERSION : undefined };
+}
+export async function withQqInstanceOperation<T>(operation: () => Promise<T>): Promise<T> {
+  if (busy) throw new Error("QQ 实例操作进行中，请稍候");
+  busy = true;
+  try { return await operation(); }
+  catch (error) { phase = "error"; message = error instanceof Error ? error.message : "QQ 实例操作失败"; throw error; }
+  finally { busy = false; }
+}
+function persist(instance: QqInstance): void {
+  fs.mkdirSync(qqInstanceRoot(), { recursive: true });
+  fs.writeFileSync(manifest() + ".tmp", JSON.stringify(instance, null, 2));
+  fs.renameSync(manifest() + ".tmp", manifest());
+}
+export async function createQqInstance(request: QqInstanceRequest): Promise<void> {
+  if (readQqInstance()) throw new Error("只允许一个 QQ 实例，请先删除现有实例");
+  if (!request.accountId || !/^[1-9]\d{4,9}$/.test(request.accountId)) throw new Error("请输入有效机器人 QQ 号（5 至 10 位）");
+  if (request.backend !== "napcat" && request.backend !== "snowluma") throw new Error("请选择 QQ 后端");
+  if (loadChannelsSettings().qq.enabled) throw new Error("请先停止现有 QQ 渠道，再创建受管实例");
+  phase = "installing"; message = "正在创建 QQ 实例";
+  if (request.backend === "snowluma") {
+    const root = path.join(qqInstanceRoot(), "snowluma");
+    // Kept data must never be silently assigned to another account.
+    if (fs.existsSync(path.join(root, "runtime"))) throw new Error("存在保留的 SnowLuma 数据；请先清除实例数据再创建");
+    await getSnowLumaRuntime().install();
+  }
+  const config = loadChannelsSettings().qq;
+  saveChannelsSettings({ qq: { ...config, enabled: false,
+    listenMode: "loopback", port: await freeLoopbackPort(), accessToken: randomBytes(32).toString("hex"),
+    allowedPrivateUserIds: [], allowedGroupIds: [], groupRequireMention: true,
+    blockedUserIds: [], blockedGroupIds: [],
+  } });
+  persist({ backend: request.backend, accountId: request.accountId, autoStart: false });
+  phase = "stopped"; message = request.backend === "snowluma" ? "实例已创建：未拉黑的消息默认放行，群聊仍需 @；可配置黑名单后启动" : "实例已创建，请添加白名单后启动";
+}
+export function configureQqInstance(autoStart: boolean): void {
+  const instance = readQqInstance();
+  if (!instance) throw new Error("尚未创建实例");
+  persist({ ...instance, autoStart });
+}
+export async function deleteQqInstance(removeData: boolean): Promise<void> {
+  await getSnowLumaRuntime().stop();
+  const root = qqInstanceRoot();
+  if (removeData) await fs.promises.rm(root, { recursive: true, force: true });
+  else await fs.promises.rm(manifest(), { force: true });
+  runtime = undefined; phase = "absent"; message = removeData ? "实例及数据已删除" : "实例已删除，数据仍保留在实例目录";
+}

--- a/src/main/channels/qq-instance.ts
+++ b/src/main/channels/qq-instance.ts
@@ -53,19 +53,31 @@ export async function createQqInstance(request: QqInstanceRequest): Promise<void
   if (request.backend !== "napcat" && request.backend !== "snowluma") throw new Error("请选择 QQ 后端");
   if (loadChannelsSettings().qq.enabled) throw new Error("请先停止现有 QQ 渠道，再创建受管实例");
   phase = "installing"; message = "正在创建 QQ 实例";
-  if (request.backend === "snowluma") {
-    const root = path.join(qqInstanceRoot(), "snowluma");
-    // Kept data must never be silently assigned to another account.
-    if (fs.existsSync(path.join(root, "runtime"))) throw new Error("存在保留的 SnowLuma 数据；请先清除实例数据再创建");
-    await getSnowLumaRuntime().install();
+  const previous = loadChannelsSettings().qq;
+  let snowlumaInstalled = false;
+  try {
+    if (request.backend === "snowluma") {
+      const root = path.join(qqInstanceRoot(), "snowluma");
+      // Kept data must never be silently assigned to another account.
+      if (fs.existsSync(path.join(root, "runtime"))) throw new Error("存在保留的 SnowLuma 数据；请先清除实例数据再创建");
+      await getSnowLumaRuntime().install();
+      snowlumaInstalled = true;
+    }
+    saveChannelsSettings({ qq: { ...previous, enabled: false,
+      listenMode: "loopback", port: await freeLoopbackPort(), accessToken: randomBytes(32).toString("hex"),
+      allowedPrivateUserIds: [], allowedGroupIds: [], groupRequireMention: true,
+      blockedUserIds: [], blockedGroupIds: [],
+    } });
+    persist({ backend: request.backend, accountId: request.accountId, autoStart: false });
+  } catch (error) {
+    // 事务式回滚：本次已安装 runtime 且后续步骤失败时，恢复设置并删除新建目录，
+    // 避免留下被前置校验拒绝、需手动清数据才能重建的状态。
+    if (snowlumaInstalled) {
+      try { saveChannelsSettings({ qq: previous }); } catch { /* 尽力回滚 */ }
+      try { fs.rmSync(path.join(qqInstanceRoot(), "snowluma", "runtime"), { recursive: true, force: true }); } catch { /* 尽力回滚 */ }
+    }
+    throw error;
   }
-  const config = loadChannelsSettings().qq;
-  saveChannelsSettings({ qq: { ...config, enabled: false,
-    listenMode: "loopback", port: await freeLoopbackPort(), accessToken: randomBytes(32).toString("hex"),
-    allowedPrivateUserIds: [], allowedGroupIds: [], groupRequireMention: true,
-    blockedUserIds: [], blockedGroupIds: [],
-  } });
-  persist({ backend: request.backend, accountId: request.accountId, autoStart: false });
   phase = "stopped"; message = request.backend === "snowluma" ? "实例已创建：未拉黑的消息默认放行，群聊仍需 @；可配置黑名单后启动" : "实例已创建，请添加白名单后启动";
 }
 export function configureQqInstance(autoStart: boolean): void {

--- a/src/main/channels/settings-store.test.ts
+++ b/src/main/channels/settings-store.test.ts
@@ -68,6 +68,8 @@ describe("channels/settings-store", () => {
       accessToken: "qq-secret",
       allowedPrivateUserIds: [" 10001 ", "bad", "10001"],
       allowedGroupIds: ["20001"],
+      blockedUserIds: [" 30001 ", "bad", "30001"],
+      blockedGroupIds: ["40001"],
       groupRequireMention: true,
       groupReplyStyle: "reply-and-mention",
       groupToolPolicy: "off",
@@ -79,6 +81,8 @@ describe("channels/settings-store", () => {
     expect(loaded.qq.accessToken).toBe("qq-secret");
     expect(loaded.qq.allowedPrivateUserIds).toEqual(["10001"]);
     expect(loaded.qq.allowedGroupIds).toEqual(["20001"]);
+    expect(loaded.qq.blockedUserIds).toEqual(["30001"]);
+    expect(loaded.qq.blockedGroupIds).toEqual(["40001"]);
   });
 
   it("saveChannelsSettings + load: 私密字段加密落盘 + 解密还原", () => {

--- a/src/main/channels/settings-store.ts
+++ b/src/main/channels/settings-store.ts
@@ -161,6 +161,9 @@ export interface QqChannelConfig extends ChannelRuntimeConfig {
   accessToken?: string;
   allowedPrivateUserIds: string[];
   allowedGroupIds: string[];
+  /** SnowLuma-only deny lists. NapCat retains the existing allow lists. */
+  blockedUserIds?: string[];
+  blockedGroupIds?: string[];
   groupRequireMention: true;
   groupReplyStyle: "reply-and-mention";
   groupToolPolicy: "off";
@@ -219,6 +222,8 @@ const DEFAULT_SETTINGS: ChannelsSettings = {
     port: 6200,
     allowedPrivateUserIds: [],
     allowedGroupIds: [],
+    blockedUserIds: [],
+    blockedGroupIds: [],
     groupRequireMention: true,
     groupReplyStyle: "reply-and-mention",
     groupToolPolicy: "off",
@@ -312,6 +317,8 @@ feishu: {
       accessToken: typeof q?.accessToken === "string" ? q.accessToken : undefined,
       allowedPrivateUserIds: normalizeIds(q?.allowedPrivateUserIds),
       allowedGroupIds: normalizeIds(q?.allowedGroupIds),
+      blockedUserIds: normalizeIds(q?.blockedUserIds),
+      blockedGroupIds: normalizeIds(q?.blockedGroupIds),
       groupRequireMention: true,
       groupReplyStyle: "reply-and-mention",
       groupToolPolicy: "off",

--- a/src/main/channels/snowluma-guardian.test.ts
+++ b/src/main/channels/snowluma-guardian.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import ts from "typescript";
+
+describe("SnowLuma guardian without real QQ", () => {
+  it("reaps its fake runtime when the owner pipe closes", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "cyrene-guardian-test-"));
+    const source = await fs.readFile(path.join(__dirname, "snowluma-guardian.ts"), "utf8");
+    await fs.writeFile(path.join(root, "guardian.cjs"), ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+    }).outputText);
+    await fs.writeFile(path.join(root, "index.mjs"), 'console.log(process.pid);setInterval(()=>{},1000);');
+    const guardian = spawn(process.execPath, [path.join(root, "guardian.cjs")], { cwd: root, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] });
+    let childPid = 0;
+    const exit = once(guardian, "exit");
+    try {
+      const [data] = await once(guardian.stdout!, "data");
+      childPid = Number(String(data).trim());
+      expect(childPid).toBeGreaterThan(0);
+      process.kill(childPid, 0);
+      guardian.stdin!.end();
+      await exit;
+      expect(() => process.kill(childPid, 0)).toThrow();
+    } finally {
+      guardian.stdin?.end();
+      if (childPid) { try { process.kill(childPid); } catch {} }
+      if (guardian.exitCode === null) guardian.kill();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 15000);
+});

--- a/src/main/channels/snowluma-guardian.ts
+++ b/src/main/channels/snowluma-guardian.ts
@@ -1,0 +1,27 @@
+// Executed with SnowLuma's bundled Node, never imported into Electron.
+// Closing Electron's stdin pipe also closes the owned runtime after a crash.
+import { spawn } from "node:child_process";
+
+if (require.main === module) {
+  const child = spawn(process.execPath, ["index.mjs"], {
+    cwd: process.cwd(), env: process.env, shell: false, windowsHide: true,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  let stopping = false;
+  const stop = () => {
+    if (stopping || !child.pid) return;
+    stopping = true;
+    if (process.platform === "win32") {
+      const killer = spawn("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
+        windowsHide: true, shell: false, stdio: "ignore",
+      });
+      killer.on("error", () => child.kill());
+    } else child.kill("SIGTERM");
+  };
+  process.stdin.resume();
+  process.stdin.on("end", stop);
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+  child.on("error", () => process.exit(1));
+  child.on("exit", code => process.exit(code ?? 0));
+}

--- a/src/main/channels/snowluma-guardian.ts
+++ b/src/main/channels/snowluma-guardian.ts
@@ -16,6 +16,8 @@ if (require.main === module) {
         windowsHide: true, shell: false, stdio: "ignore",
       });
       killer.on("error", () => child.kill());
+      // taskkill 启动成功但失败（如权限不足）时也要兜底，否则进程残留会占住端口。
+      killer.on("exit", code => { if (code !== 0) child.kill(); });
     } else child.kill("SIGTERM");
   };
   process.stdin.resume();

--- a/src/main/channels/snowluma-runtime.test.ts
+++ b/src/main/channels/snowluma-runtime.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSnowLumaConfig, validateArchiveEntry, prepareSnowLumaWebUi, freeLoopbackPort } from "./snowluma-runtime";
+import { makeSessionId } from "./channel-context";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "node:net";
+
+const roots: string[] = [];
+async function fixture() { const root = await fs.mkdtemp(path.join(os.tmpdir(), "cyrene-sl-config-")); roots.push(root); return root; }
+afterEach(async () => { for (const root of roots.splice(0)) await fs.rm(root, { recursive: true, force: true }); });
+
+describe("managed QQ isolation", () => {
+  it("only connects to the owned loopback listener with authentication", () => {
+    const cfg = buildSnowLumaConfig("123456789", 16200, "test-token");
+    expect(cfg.networks.httpServers).toEqual([]);
+    expect(cfg.networks.wsServers).toEqual([]);
+    expect(cfg.networks.wsClients).toEqual([expect.objectContaining({
+      url: "ws://127.0.0.1:16200/onebot/v11/ws", accessToken: "test-token", enabled: true, reportSelfMessage: false,
+    })]);
+    expect(() => buildSnowLumaConfig("../account", 16200, "token")).toThrow();
+    expect(() => buildSnowLumaConfig("123456789", 0, "token")).toThrow();
+    expect(() => buildSnowLumaConfig("123456789", 16200, "")).toThrow();
+  });
+  it("rejects traversal, absolute paths and symlinks before extraction", () => {
+    for (const entry of ["../escape", "foo/../../escape", "C:/escape", "/escape", "foo\\..\\escape", ".. /escape", "con.txt"]) {
+      expect(() => validateArchiveEntry(entry, 0)).toThrow();
+    }
+    expect(() => validateArchiveEntry("native/link", 0o120777)).toThrow();
+    expect(() => validateArchiveEntry("native/snowluma.dll", 0o100644)).not.toThrow();
+  });
+  it("separates account histories while retaining legacy session keys", () => {
+    const first = makeSessionId("qq", "group", "11111");
+    expect(first).not.toBe(makeSessionId("qq", "group", "22222"));
+    expect(first).not.toBe(makeSessionId("qq", "group"));
+    expect(makeSessionId("qq", "group")).toBe(makeSessionId("qq", "group", undefined));
+  });
+  it("persists a WebUI port and reuses it across starts", async () => {
+    const root = await fixture();
+    const first = await prepareSnowLumaWebUi(root);
+    expect(await prepareSnowLumaWebUi(root)).toBe(first);
+    const config = JSON.parse(await fs.readFile(path.join(root, "runtime.json"), "utf8"));
+    expect(config).toMatchObject({ webuiPort: first, webuiHost: "127.0.0.1", hookAutoLoad: false });
+  });
+  it("adopts the first version's existing WebUI port without changing credentials", async () => {
+    const root = await fixture();
+    const port = await freeLoopbackPort();
+    await fs.writeFile(path.join(root, "runtime.json"), JSON.stringify({ webuiPort: port, customSetting: "preserve" }));
+    await fs.writeFile(path.join(root, "webui-auth.json"), "credential-sentinel");
+    expect(await prepareSnowLumaWebUi(root)).toBe(port);
+    expect(await fs.readFile(path.join(root, "webui-auth.json"), "utf8")).toBe("credential-sentinel");
+    expect(JSON.parse(await fs.readFile(path.join(root, "runtime.json"), "utf8")).customSetting).toBe("preserve");
+  });
+  it("fails on a port conflict instead of silently moving the WebUI", async () => {
+    const root = await fixture();
+    const occupied = createServer();
+    await new Promise<void>(resolve => occupied.listen(0, "127.0.0.1", resolve));
+    try {
+      const port = (occupied.address() as import("node:net").AddressInfo).port;
+      await fs.writeFile(path.join(root, "runtime.json"), JSON.stringify({ webuiPort: port }));
+      await expect(prepareSnowLumaWebUi(root)).rejects.toThrow("不可用");
+      expect(JSON.parse(await fs.readFile(path.join(root, "runtime.json"), "utf8")).webuiPort).toBe(port);
+    } finally { await new Promise<void>(resolve => occupied.close(() => resolve())); }
+  });
+});

--- a/src/main/channels/snowluma-runtime.ts
+++ b/src/main/channels/snowluma-runtime.ts
@@ -1,0 +1,225 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import { createServer } from "node:net";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import * as yauzl from "yauzl";
+import { ONEBOT_WS_PATH } from "./adapters/qq/onebot-reverse-ws";
+
+export const SNOWLUMA_VERSION = "1.14.15";
+export const SNOWLUMA_SHA256 = "ab657f8121f8b503c8637ae9bf47d8982e4925897d9aa5d99056e04638f05809";
+const ASSET_URL = `https://github.com/SnowLuma/SnowLuma/releases/download/v${SNOWLUMA_VERSION}/SnowLuma-v${SNOWLUMA_VERSION}-win-x64.zip`;
+
+export function buildSnowLumaConfig(account: string, port: number, token: string) {
+  if (!/^[1-9]\d{4,9}$/.test(account) || !token || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("QQ 账号、端口或 Token 无效");
+  }
+  return {
+    networks: { httpServers: [], httpClients: [], wsServers: [], wsClients: [{
+      name: "cyrene", enabled: true, url: `ws://127.0.0.1:${port}${ONEBOT_WS_PATH}`,
+      role: "Universal", accessToken: token, messageFormat: "array",
+      reportSelfMessage: false, reconnectIntervalMs: 3000,
+    }] },
+  };
+}
+
+export function validateArchiveEntry(name: string, mode: number): void {
+  const normalized = name.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || normalized.includes(":") || normalized.split("/").some(part =>
+    part === ".." || /[ .]$/.test(part) || /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(part))
+    || (mode & 0o170000) === 0o120000) throw new Error("压缩包包含不安全路径");
+}
+
+export async function freeLoopbackPort(): Promise<number> {
+  const server = createServer();
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as { port: number }).port;
+      server.close(error => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+/** Reuse the existing origin, including migrating first-version instances. */
+export async function prepareSnowLumaWebUi(configDirectory: string): Promise<number> {
+  await fs.mkdir(configDirectory, { recursive: true });
+  const runtimePath = path.join(configDirectory, "runtime.json");
+  const previous = await fs.readFile(runtimePath, "utf8").then(JSON.parse).catch(error => {
+    if (error.code === "ENOENT") return {};
+    throw new Error("SnowLuma runtime.json 无法读取，请检查实例配置后重试");
+  });
+  const port = previous.webuiPort === undefined ? await freeLoopbackPort() : previous.webuiPort;
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) throw new Error("SnowLuma WebUI 端口无效，请检查 runtime.json");
+  // Do not silently change origin on conflict or terminate another application's listener.
+  const probe = createServer();
+  await new Promise<void>((resolve, reject) => {
+    probe.once("error", () => reject(new Error(`SnowLuma WebUI 端口 ${port} 不可用，请释放该端口后重试`)));
+    probe.listen(port, "127.0.0.1", () => probe.close(error => error ? reject(error) : resolve()));
+  });
+  await fs.writeFile(runtimePath, JSON.stringify({ ...previous, webuiHost: "127.0.0.1", webuiPort: port,
+    webuiTls: { enabled: false }, hookAutoLoad: false, logMaxTotalMb: 256, logRetainDays: 7 }, null, 2));
+  return port;
+}
+
+export async function extractSnowLumaArchive(archive: string, destination: string): Promise<void> {
+  const zip = await new Promise<yauzl.ZipFile>((resolve, reject) =>
+    yauzl.open(archive, { lazyEntries: true }, (error, value) => error ? reject(error) : resolve(value!)));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let bytes = 0;
+      zip.once("error", reject);
+      zip.once("end", resolve);
+      zip.on("entry", (entry: yauzl.Entry) => {
+        void (async () => {
+          validateArchiveEntry(entry.fileName, entry.externalFileAttributes >>> 16);
+          bytes += entry.uncompressedSize;
+          if (bytes > 1024 * 1024 * 1024) throw new Error("SnowLuma 解压大小超过限制");
+          const target = path.join(destination, entry.fileName);
+          if (entry.fileName.endsWith("/")) await fs.mkdir(target, { recursive: true });
+          else {
+            await fs.mkdir(path.dirname(target), { recursive: true });
+            const input = await new Promise<import("node:stream").Readable>((ok, fail) =>
+              zip.openReadStream(entry, (error, stream) => error ? fail(error) : ok(stream!)));
+            await pipeline(input, createWriteStream(target, { flags: "wx" }));
+          }
+          zip.readEntry();
+        })().catch(reject);
+      });
+      zip.readEntry();
+    });
+  } finally { zip.close(); }
+}
+
+export class SnowLumaRuntime {
+  private child: ChildProcess | null = null;
+  webuiUrl: string | undefined;
+  constructor(readonly root: string, private readonly notify: (message: string, failed?: boolean) => void) {}
+
+  async install(): Promise<void> {
+    if (process.platform !== "win32" || process.arch !== "x64") throw new Error("首版内置安装仅支持 Windows x64");
+    await fs.mkdir(this.root, { recursive: true });
+    const stage = await fs.mkdtemp(path.join(this.root, "staging-"));
+    const archive = path.join(stage, "snowluma.zip");
+    try {
+      const response = await fetch(ASSET_URL, { signal: AbortSignal.timeout(180_000) });
+      if (!response.ok || !response.body) throw new Error(`SnowLuma 下载失败 (${response.status})`);
+      const file = await fs.open(archive, "w");
+      const hash = createHash("sha256");
+      let count = 0;
+      let announced = 0;
+      try {
+        for await (const chunk of response.body) {
+          count += chunk.length;
+          if (count > 100 * 1024 * 1024) throw new Error("SnowLuma 下载超过大小限制");
+          hash.update(chunk);
+          await file.writeFile(chunk);
+          const mb = Math.floor(count / 1048576);
+          if (mb !== announced) { announced = mb; this.notify(`下载 SnowLuma：${mb} MiB`); }
+        }
+      } finally { await file.close(); }
+      if (hash.digest("hex") !== SNOWLUMA_SHA256) throw new Error("SnowLuma SHA-256 校验失败");
+      const unpack = path.join(stage, "unpacked");
+      await extractSnowLumaArchive(archive, unpack);
+      // Official archives may have a single enclosing directory.
+      let source = unpack;
+      if (!await exists(path.join(source, "index.mjs"))) {
+        const dirs = (await fs.readdir(unpack, { withFileTypes: true })).filter(e => e.isDirectory());
+        if (dirs.length !== 1) throw new Error("SnowLuma 包结构无效");
+        source = path.join(unpack, dirs[0].name);
+      }
+      for (const file of ["index.mjs", "node.exe", "package.json", "native"]) await fs.access(path.join(source, file));
+      await fs.writeFile(path.join(source, "cyrene-installation.json"), JSON.stringify({
+        version: SNOWLUMA_VERSION, sha256: SNOWLUMA_SHA256, url: ASSET_URL,
+      }, null, 2));
+      await fs.rename(source, path.join(this.root, "runtime"));
+    } finally { await fs.rm(stage, { recursive: true, force: true }); }
+  }
+
+  async start(account: string, port: number, token: string): Promise<void> {
+    if (this.child) throw new Error("SnowLuma 已启动");
+    const cwd = path.join(this.root, "runtime");
+    const config = path.join(cwd, "config");
+    await fs.mkdir(config, { recursive: true });
+    const webPort = await prepareSnowLumaWebUi(config);
+    // A disabled adapter prevents SnowLuma's empty-network default fallback.
+    const disabled = buildSnowLumaConfig(account, port, token);
+    disabled.networks.wsClients[0].enabled = false;
+    await fs.writeFile(path.join(config, "onebot.json"), JSON.stringify(disabled));
+    await fs.writeFile(path.join(config, `onebot_${account}.json`), JSON.stringify(buildSnowLumaConfig(account, port, token)));
+    const local = path.join(this.root, "environment");
+    for (const dir of ["home", "temp", "appdata", "localappdata"]) await fs.mkdir(path.join(local, dir), { recursive: true });
+    const inherited = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.toUpperCase().startsWith("SNOWLUMA_")));
+    const env: NodeJS.ProcessEnv = { ...inherited,
+      HOME: path.join(local, "home"), USERPROFILE: path.join(local, "home"),
+      APPDATA: path.join(local, "appdata"), LOCALAPPDATA: path.join(local, "localappdata"),
+      TEMP: path.join(local, "temp"), TMP: path.join(local, "temp"),
+      SNOWLUMA_HOOK_AUTOLOAD: "0", SNOWLUMA_WEBUI_PORT: String(webPort), SNOWLUMA_WEBUI_HOST: "127.0.0.1",
+      SNOWLUMA_LOG_DIR: path.join(cwd, "logs"),
+    };
+    for (const key of ["ELECTRON_RUN_AS_NODE", "NODE_OPTIONS", "SNOWLUMA_DEV_MODE", "SNOWLUMA_ACCEPT_EULA", "SNOWLUMA_ACCEPT_PRIVACY"]) delete env[key];
+    // External Node cannot read Electron's app.asar filesystem.
+    const guardian = path.join(this.root, "snowluma-guardian.cjs");
+    await fs.writeFile(guardian, await fs.readFile(path.join(__dirname, "snowluma-guardian.js")));
+    const child = spawn(path.join(cwd, "node.exe"), [guardian], {
+      cwd, env, shell: false, windowsHide: true, stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child = child;
+    let recent = "";
+    let credentialsSaved = false;
+    let credentialsWrite: Promise<void> = Promise.resolve();
+    const read = (data: Buffer) => {
+      // Do not forward SnowLuma output: it can contain passwords, tokens and message bodies.
+      recent = (recent + data.toString("utf8")).slice(-8192);
+      // SL deliberately prints the initial credential only to stdout, not its logs.
+      // Keep it in an explicitly named private file, never in IPC/status or general logs.
+      const credential = recent.match(/initial credentials: user=admin password=([a-f0-9]{16})/);
+      if (credential && !credentialsSaved) {
+        credentialsSaved = true;
+        credentialsWrite = fs.writeFile(path.join(this.root, "webui-initial-credentials.txt"),
+          `Username: admin\nInitial password: ${credential[1]}\nChange this password in WebUI, then delete this file.\n`, { mode: 0o600 });
+        void credentialsWrite.catch(() => this.notify("无法保存初始 WebUI 凭据，请停止后重试", true));
+      }
+      const match = recent.match(/listening http:\/\/127\.0\.0\.1:(\d+)/);
+      if (match) this.webuiUrl = `http://127.0.0.1:${Number(match[1])}/`;
+    };
+    child.stdout?.on("data", read);
+    child.stderr?.on("data", read);
+    child.on("error", () => {
+      if (this.child === child) this.child = null;
+      this.notify("SnowLuma 进程启动失败", true);
+    });
+    child.once("exit", code => {
+      if (this.child === child) { this.child = null; this.webuiUrl = undefined; this.notify(`SnowLuma 已退出 (${code ?? "signal"})`, true); }
+    });
+    const deadline = Date.now() + 45_000;
+    while (Date.now() < deadline) {
+      if (!this.child) throw new Error("SnowLuma 启动期间退出");
+      if (this.webuiUrl) {
+        if (this.webuiUrl !== `http://127.0.0.1:${webPort}/`) {
+          await this.stop();
+          throw new Error(`WebUI 未绑定固定端口 ${webPort}，请检查端口占用后重试`);
+        }
+        await credentialsWrite;
+        this.notify("SnowLuma WebUI 已启动；OneBot 地址和 Token 已自动配置"); return;
+      }
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+    await this.stop();
+    throw new Error("SnowLuma WebUI 启动超时");
+  }
+
+  async stop(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+    this.webuiUrl = undefined;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("SnowLuma 停止超时，请检查该实例进程")), 10_000);
+      child.once("exit", () => { clearTimeout(timer); if (this.child === child) this.child = null; resolve(); });
+      child.stdin?.end();
+    });
+  }
+}
+async function exists(file: string): Promise<boolean> { return fs.access(file).then(() => true, () => false); }

--- a/src/main/channels/snowluma-runtime.ts
+++ b/src/main/channels/snowluma-runtime.ts
@@ -95,6 +95,7 @@ export async function extractSnowLumaArchive(archive: string, destination: strin
 
 export class SnowLumaRuntime {
   private child: ChildProcess | null = null;
+  private stopping = false;
   webuiUrl: string | undefined;
   constructor(readonly root: string, private readonly notify: (message: string, failed?: boolean) => void) {}
 
@@ -192,7 +193,8 @@ export class SnowLumaRuntime {
       this.notify("SnowLuma 进程启动失败", true);
     });
     child.once("exit", code => {
-      if (this.child === child) { this.child = null; this.webuiUrl = undefined; this.notify(`SnowLuma 已退出 (${code ?? "signal"})`, true); }
+      // 主动停止不报失败；停止超时后 stopping 已复位，此后的退出仍按异常上报。
+      if (this.child === child && !this.stopping) { this.child = null; this.webuiUrl = undefined; this.notify(`SnowLuma 已退出 (${code ?? "signal"})`, true); }
     });
     const deadline = Date.now() + 45_000;
     while (Date.now() < deadline) {
@@ -215,11 +217,14 @@ export class SnowLumaRuntime {
     const child = this.child;
     if (!child) return;
     this.webuiUrl = undefined;
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("SnowLuma 停止超时，请检查该实例进程")), 10_000);
-      child.once("exit", () => { clearTimeout(timer); if (this.child === child) this.child = null; resolve(); });
-      child.stdin?.end();
-    });
+    this.stopping = true;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("SnowLuma 停止超时，请检查该实例进程")), 10_000);
+        child.once("exit", () => { clearTimeout(timer); if (this.child === child) this.child = null; resolve(); });
+        child.stdin?.end();
+      });
+    } finally { this.stopping = false; }
   }
 }
 async function exists(file: string): Promise<boolean> { return fs.access(file).then(() => true, () => false); }

--- a/src/main/channels/types.ts
+++ b/src/main/channels/types.ts
@@ -60,6 +60,8 @@ export interface ChannelAttachment {
 
 /** 入站消息。adapters → dispatcher。 */
 export interface IncomingMessage {
+  /** Managed backend account namespace. Legacy adapters leave this undefined. */
+  accountId?: string;
   channel: ChannelId;
   /** 私聊或群聊。旧渠道未声明时按 private 处理。 */
   chatType?: ChannelChatType;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -427,6 +427,7 @@ const settingsApi = {
   channelsFeishuTestConnection: () => ipcRenderer.invoke(IPC.CHANNELS_FEISHU_TEST_CONNECTION),
   channelsFeishuTestWebhookReachable: () => ipcRenderer.invoke(IPC.CHANNELS_FEISHU_TEST_WEBHOOK_REACHABLE),
   channelsQqTestConnection: () => ipcRenderer.invoke(IPC.CHANNELS_QQ_TEST_CONNECTION),
+  channelsQqInstance: (request: import("../shared/qq-instance").QqInstanceRequest) => ipcRenderer.invoke(IPC.CHANNELS_QQ_INSTANCE, request),
   channelsQqBotTestConnection: () => ipcRenderer.invoke(IPC.CHANNELS_QQBOT_TEST_CONNECTION),
   // 消息日志
   channelsLogGet: (limit?: number) => ipcRenderer.invoke(IPC.CHANNELS_LOG_GET, limit ?? 100),

--- a/src/renderer/settings/channels/panel.ts
+++ b/src/renderer/settings/channels/panel.ts
@@ -3,6 +3,7 @@
 // general/dom 的 proactiveDeliverySelect + shared 的 normalize/isProactiveDeliveryTargetSelectable。
 
 import { channelsState } from "./state";
+import { bindQqInstancePanel } from "./qq-instance-panel";
 import {
   channelsWechatEnabledEl, channelsFeishuEnabledEl, channelsQqEnabledEl,
   channelsRateUserEl, channelsRateChannelEl,
@@ -254,7 +255,9 @@ export async function refreshContextBindings(): Promise<void> {
   }
 }
 
+let qqInstancePanelBound = false;
 export async function loadChannelsPanel(): Promise<void> {
+  if (!qqInstancePanelBound) { qqInstancePanelBound = true; bindQqInstancePanel(loadChannelsPanel); }
   if (channelsState.initialized) {
     await refreshContextBindings();
     return;
@@ -562,9 +565,12 @@ export async function loadChannelsPanel(): Promise<void> {
     };
     if (channelsQqTokenEl?.value) qq.accessToken = channelsQqTokenEl.value;
     try {
+      const instance = await window.settings.channelsQqInstance({ action: "status" });
       await window.settings.channelsSaveConfig({ qq });
       if (qq.accessToken) hadQqToken = true;
-      await window.settings.channelsRestart();
+      if (instance.instance) {
+        await window.settings.channelsQqInstance({ action: qq.enabled ? "restart" : "stop" });
+      } else await window.settings.channelsRestart();
       const status = await window.settings.channelsGetStatus() as Record<string, { phase?: string; message?: string; detail?: Record<string, unknown> }>;
       renderQqDetail(status.qq);
       if (channelsQqTokenEl) {
@@ -572,7 +578,7 @@ export async function loadChannelsPanel(): Promise<void> {
         channelsQqTokenEl.type = "password";
         channelsQqTokenEl.placeholder = "已保存（输入新值会覆盖）";
       }
-      setQqFeedback("ok", "已启动监听；请在 NapCat 中新增 WebSocket Client，并使用上方 URL。");
+      setQqFeedback("ok", instance.instance?.backend === "snowluma" ? "配置已保存；请通过 SnowLuma WebUI 管理登录。" : "配置已保存；请在 NapCat 配置上方连接 URL。");
     } catch (error) {
       setQqFeedback("err", error instanceof Error ? error.message : String(error));
     }

--- a/src/renderer/settings/channels/qq-instance-panel.test.ts
+++ b/src/renderer/settings/channels/qq-instance-panel.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { bindQqInstancePanel } from "./qq-instance-panel";
+
+afterEach(() => { window.dispatchEvent(new Event("beforeunload")); vi.unstubAllGlobals(); });
+describe("managed QQ settings panel", () => {
+  it("locks a created account and exposes only the ready WebUI link", async () => {
+    document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
+    const call = vi.fn().mockResolvedValue({ instance: { backend: "snowluma", accountId: "123456", autoStart: false }, phase: "running", message: "ready", root: "E:/owned", webuiUrl: "http://127.0.0.1:16300/" });
+    Object.defineProperty(window, "settings", { configurable: true, value: { channelsQqInstance: call, channelsGetConfig: vi.fn().mockResolvedValue({ qq: {} }) } });
+    bindQqInstancePanel(async () => {});
+    await vi.waitFor(() => expect((document.querySelector("#qq-instance-account") as HTMLInputElement).disabled).toBe(true));
+    expect((document.querySelector('[data-action="create"]') as HTMLButtonElement).disabled).toBe(true);
+    expect((document.querySelector('[data-action="open"]') as HTMLButtonElement).disabled).toBe(false);
+    expect((document.querySelector("#qq-instance-url") as HTMLInputElement).value).toBe("http://127.0.0.1:16300/");
+    expect((document.querySelector("#channels-qq-port") as HTMLInputElement).disabled).toBe(true);
+    expect(document.querySelector("#qq-instance-feedback")?.textContent).toContain("运行中");
+  });
+  it("allows explicit cleanup of retained data even after deleting the manifest", async () => {
+    document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
+    Object.defineProperty(window, "settings", { configurable: true, value: { channelsQqInstance: vi.fn().mockResolvedValue({ instance: null, phase: "absent", message: "retained", root: "E:/owned" }), channelsGetConfig: vi.fn().mockResolvedValue({ qq: {} }) } });
+    bindQqInstancePanel(async () => {});
+    await vi.waitFor(() => expect(document.querySelector("#qq-instance-feedback")?.textContent).toContain("未创建"));
+    expect((document.querySelector('[data-action="delete"]') as HTMLButtonElement).disabled).toBe(false);
+    expect((document.querySelector('[data-action="start"]') as HTMLButtonElement).disabled).toBe(true);
+  });
+  it("separates backend cards and keeps tutorials collapsed", () => {
+    document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
+    const sl = document.querySelector("#qq-snowluma-card")!;
+    const napcat = document.querySelector("#qq-napcat-card")!;
+    expect(sl).not.toBe(napcat);
+    expect(sl.querySelector("#channels-qq-token")).toBeNull();
+    expect(napcat.querySelector("#qq-instance-url")).toBeNull();
+    expect((sl.querySelector("details") as HTMLDetailsElement).open).toBe(false);
+    expect(sl.textContent).not.toContain("保存白名单");
+    expect(sl.textContent).toContain("空黑名单默认放行");
+    expect((napcat.querySelector("details") as HTMLDetailsElement).open).toBe(false);
+    const ids = [...document.querySelectorAll("[id]")].map(el => el.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+  it("saves SL blocklists without a restart and blocks the other backend", async () => {
+    document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
+    const instance = vi.fn().mockResolvedValue({ instance: { backend: "snowluma", accountId: "123456", autoStart: false }, phase: "running", message: "ready", root: "owned", onebotUrl: "ws://127.0.0.1:12345/onebot/v11/ws" });
+    const save = vi.fn().mockResolvedValue({});
+    Object.defineProperty(window, "settings", { configurable: true, value: { channelsQqInstance: instance, channelsGetConfig: vi.fn().mockResolvedValue({ qq: {} }), channelsSaveConfig: save } });
+    bindQqInstancePanel(async () => {});
+    await vi.waitFor(() => expect((document.querySelector("#qq-instance-save-blocklists") as HTMLButtonElement).disabled).toBe(false));
+    const users = document.querySelector("#qq-instance-user-blocklist") as HTMLTextAreaElement;
+    users.value = "234567,345678\n234567"; users.dispatchEvent(new Event("input"));
+    (document.querySelector("#qq-instance-save-blocklists") as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(save).toHaveBeenCalledWith({ qq: { blockedUserIds: ["234567", "345678"], blockedGroupIds: [] } }));
+    expect(instance.mock.calls.every(([request]) => request.action === "status")).toBe(true);
+    expect((document.querySelector('#qq-napcat-instance-panel [data-action="create"]') as HTMLButtonElement).disabled).toBe(true);
+    expect((document.querySelector("#qq-instance-onebot-url") as HTMLInputElement).value).toContain("/onebot/v11/ws");
+  });
+});

--- a/src/renderer/settings/channels/qq-instance-panel.test.ts
+++ b/src/renderer/settings/channels/qq-instance-panel.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { bindQqInstancePanel } from "./qq-instance-panel";
 
-afterEach(() => { window.dispatchEvent(new Event("beforeunload")); vi.unstubAllGlobals(); });
+afterEach(() => { window.dispatchEvent(new Event("beforeunload")); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 describe("managed QQ settings panel", () => {
   it("locks a created account and exposes only the ready WebUI link", async () => {
     document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
@@ -54,5 +54,25 @@ describe("managed QQ settings panel", () => {
     expect(instance.mock.calls.every(([request]) => request.action === "status")).toBe(true);
     expect((document.querySelector('#qq-napcat-instance-panel [data-action="create"]') as HTMLButtonElement).disabled).toBe(true);
     expect((document.querySelector("#qq-instance-onebot-url") as HTMLInputElement).value).toContain("/onebot/v11/ws");
+  });
+  it("clears a stale operation error once polling succeeds again", async () => {
+    document.documentElement.innerHTML = fs.readFileSync(path.join(__dirname, "../index.html"), "utf8");
+    const status = { instance: { backend: "snowluma", accountId: "123456", autoStart: false }, phase: "running", message: "ready", root: "owned", webuiUrl: "http://127.0.0.1:16300/" };
+    let actionCalls = 0;
+    const instance = vi.fn().mockImplementation((request: { action: string }) => {
+      if (request.action === "status") return Promise.resolve(status);
+      actionCalls += 1;
+      return actionCalls === 1 ? Promise.reject(new Error("启动失败：端口被占用")) : Promise.resolve(status);
+    });
+    let poll: (() => void) | undefined;
+    vi.spyOn(window, "setInterval").mockImplementation(((cb: () => void) => { poll = cb; return 1; }) as unknown as typeof window.setInterval);
+    Object.defineProperty(window, "settings", { configurable: true, value: { channelsQqInstance: instance, channelsGetConfig: vi.fn().mockResolvedValue({ qq: {} }) } });
+    bindQqInstancePanel(async () => {});
+    await vi.waitFor(() => expect(document.querySelector("#qq-instance-feedback")?.textContent).toContain("运行中"));
+    (document.querySelector('[data-action="start"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(document.querySelector("#qq-instance-feedback")?.textContent).toContain("启动失败：端口被占用"));
+    poll?.();
+    await vi.waitFor(() => expect(document.querySelector("#qq-instance-feedback")?.textContent).toContain("运行中"));
+    expect(document.querySelector("#qq-instance-feedback")?.textContent).not.toContain("端口被占用");
   });
 });

--- a/src/renderer/settings/channels/qq-instance-panel.ts
+++ b/src/renderer/settings/channels/qq-instance-panel.ts
@@ -59,6 +59,8 @@ export function bindQqInstancePanel(onChanged: () => Promise<void>): void {
   const refresh = async () => {
     try {
       const state = await window.settings.channelsQqInstance({ action: "status" });
+      // 操作失败后轮询恢复时不能继续显示过期错误，render 优先展示 lastError。
+      lastError = "";
       render(state);
       const config = await window.settings.channelsGetConfig() as QqPublicConfig;
       if (!dirty || draftAccount !== state.instance?.accountId) {

--- a/src/renderer/settings/channels/qq-instance-panel.ts
+++ b/src/renderer/settings/channels/qq-instance-panel.ts
@@ -1,0 +1,122 @@
+import type { QqBackend, QqInstanceRequest, QqInstanceStatus } from "../../../shared/qq-instance";
+
+interface QqPublicConfig { qq?: { enabled?: boolean; blockedUserIds?: string[]; blockedGroupIds?: string[] } }
+
+export function bindQqInstancePanel(onChanged: () => Promise<void>): void {
+  const panels = [
+    { prefix: "qq-instance", backend: "snowluma" as QqBackend, element: document.getElementById("qq-instance-panel") },
+    { prefix: "qq-napcat-instance", backend: "napcat" as QqBackend, element: document.getElementById("qq-napcat-instance-panel") },
+  ].filter(item => item.element);
+  if (!panels.length) return;
+  const privateList = document.getElementById("qq-instance-user-blocklist") as HTMLTextAreaElement;
+  const groupList = document.getElementById("qq-instance-group-blocklist") as HTMLTextAreaElement;
+  const save = document.getElementById("qq-instance-save-blocklists") as HTMLButtonElement;
+  const saveFeedback = document.getElementById("qq-instance-save-feedback")!;
+  let busy = false;
+  let current: QqInstanceStatus | undefined;
+  let dirty = false;
+  let draftAccount: string | undefined;
+  let lastError = "";
+  const field = <T extends HTMLElement>(prefix: string, suffix: string) => document.getElementById(prefix + "-" + suffix) as T;
+  const render = (state: QqInstanceStatus) => {
+    current = state;
+    const phases = { absent: "未创建", installing: "安装中", stopped: "已停止", starting: "启动中", running: "运行中", error: "异常" };
+    const locked = busy || state.phase === "installing";
+    for (const { prefix, backend, element } of panels) {
+      const owned = state.instance?.backend === backend;
+      const occupied = Boolean(state.instance && !owned);
+      const account = field<HTMLInputElement>(prefix, "account");
+      const auto = field<HTMLInputElement>(prefix, "auto");
+      const feedback = field<HTMLElement>(prefix, "feedback");
+      feedback.textContent = occupied ? "另一 QQ 后端已占用唯一实例；请先在对应卡片停止并删除实例。" :
+        lastError || `${phases[state.phase]} · ${state.message}\n数据目录：${state.root}`;
+      account.disabled = locked || Boolean(state.instance);
+      auto.disabled = locked || !owned;
+      if (owned) { account.value = state.instance!.accountId; auto.checked = state.instance!.autoStart; }
+      for (const button of element!.querySelectorAll<HTMLButtonElement>("button[data-action]")) {
+        const action = button.dataset.action;
+        button.disabled = locked || occupied || (action === "create" ? Boolean(state.instance) :
+          action === "open" ? !owned || !state.webuiUrl : action === "delete" ? backend === "napcat" && !owned : !owned);
+      }
+    }
+    field<HTMLInputElement>("qq-instance", "url").value = state.instance?.backend === "snowluma" ? state.webuiUrl ?? "" : "";
+    field<HTMLInputElement>("qq-instance", "onebot-url").value = state.onebotUrl ?? "";
+    const slOwned = state.instance?.backend === "snowluma";
+    privateList.disabled = groupList.disabled = save.disabled = locked || !slOwned;
+    // Keep legacy DOM references for existing autosave, but prevent NapCat controls
+    // from editing/restarting the SL-owned channel.
+    const napcatCard = document.getElementById("qq-napcat-card");
+    for (const control of napcatCard?.querySelectorAll<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement>('[id^="channels-qq-"]') ?? []) {
+      control.disabled = slOwned || locked;
+    }
+    const switchElement = document.getElementById("channels-qq-enabled")?.parentElement;
+    if (switchElement) switchElement.hidden = slOwned;
+    const legacyStatus = document.getElementById("channels-qq-status");
+    if (legacyStatus) legacyStatus.hidden = slOwned;
+    const legacyControls = document.getElementById("qq-napcat-legacy-controls");
+    if (legacyControls) legacyControls.hidden = slOwned;
+  };
+  const refresh = async () => {
+    try {
+      const state = await window.settings.channelsQqInstance({ action: "status" });
+      render(state);
+      const config = await window.settings.channelsGetConfig() as QqPublicConfig;
+      if (!dirty || draftAccount !== state.instance?.accountId) {
+        privateList.value = (config.qq?.blockedUserIds ?? []).join("\n");
+        groupList.value = (config.qq?.blockedGroupIds ?? []).join("\n");
+        draftAccount = state.instance?.accountId;
+        dirty = false;
+      }
+    } catch (error) {
+      field<HTMLElement>("qq-instance", "feedback").textContent = error instanceof Error ? error.message : String(error);
+    }
+  };
+  const execute = async (request: QqInstanceRequest) => {
+    busy = true; lastError = "";
+    if (current) render(current);
+    try {
+      render(await window.settings.channelsQqInstance(request));
+      await onChanged();
+      const config = await window.settings.channelsGetConfig() as QqPublicConfig;
+      const enabled = document.getElementById("channels-qq-enabled") as HTMLInputElement | null;
+      if (enabled) enabled.checked = config.qq?.enabled === true;
+    } catch (error) { lastError = error instanceof Error ? error.message : String(error); }
+    finally { busy = false; if (current) render(current); }
+  };
+  for (const { prefix, backend, element } of panels) {
+    element!.addEventListener("click", event => {
+      const button = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-action]");
+      if (!button || button.disabled || busy) return;
+      const action = button.dataset.action as QqInstanceRequest["action"];
+      const removeData = backend === "snowluma" && field<HTMLInputElement>(prefix, "remove-data").checked;
+      if (action === "delete" && !window.confirm(removeData ?
+        "删除实例及 SL 安装、登录、日志？保留 Cyrene 对话和记忆。请先在 WebUI 卸载 Hook。" :
+        "删除 QQ 账号绑定？运行数据会保留，SL 重建前需勾选清理数据再删除。")) return;
+      void execute({ action, accountId: field<HTMLInputElement>(prefix, "account").value.trim(), backend, removeData });
+    });
+    field<HTMLInputElement>(prefix, "auto").addEventListener("change", () => void execute({
+      action: "configure", autoStart: field<HTMLInputElement>(prefix, "auto").checked,
+    }));
+  }
+  privateList.addEventListener("input", () => { dirty = true; });
+  groupList.addEventListener("input", () => { dirty = true; });
+  save.addEventListener("click", async () => {
+    if (busy || current?.instance?.backend !== "snowluma") return;
+    const parse = (value: string) => [...new Set(value.split(/[\s,，;；]+/).filter(Boolean))];
+    const users = parse(privateList.value), groups = parse(groupList.value);
+    if ([...users, ...groups].some(id => !/^[1-9]\d{4,11}$/.test(id))) {
+      saveFeedback.textContent = "请输入有效 QQ 号或群号，用换行或逗号分隔。"; return;
+    }
+    busy = true; if (current) render(current);
+    try {
+      await window.settings.channelsSaveConfig({ qq: { blockedUserIds: users, blockedGroupIds: groups } });
+      dirty = false;
+      saveFeedback.textContent = users.length || groups.length ? "黑名单已保存并即时生效，未重启 SL。" : "已清空黑名单：未被拉黑的消息默认放行，群聊仍需 @。";
+      await onChanged();
+    } catch (error) { saveFeedback.textContent = error instanceof Error ? error.message : String(error); }
+    finally { busy = false; if (current) render(current); }
+  });
+  void refresh();
+  const timer = window.setInterval(() => void refresh(), 2000);
+  window.addEventListener("beforeunload", () => window.clearInterval(timer), { once: true });
+}

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -1162,18 +1162,103 @@
             </div>
           </div>
 
-          <div class="channels-card">
+          <div class="channels-card" id="qq-snowluma-card">
+            <div class="channels-card__header"><h2>QQ（SnowLuma）</h2></div>
+            <div class="channels-card__body">
+              <section id="qq-instance-panel" aria-label="唯一 QQ 接入实例">
+                <p class="channels-card__hint">内置安装并管理 SnowLuma，只绑定一个机器人 QQ。与 NapCat 互斥，最多一个实例。空黑名单默认放行所有私聊，群聊仍需 @；群聊共享个人记忆，私聊工具权限沿用全局渠道设置，请使用专用机器人账号。</p>
+
+                <div class="form-row">
+                  <label class="form-label" for="qq-instance-account">机器人 QQ 号</label>
+                  <input id="qq-instance-account" class="form-input form-input--wide" inputmode="numeric" placeholder="绑定后拒绝其他账号接入" />
+                </div>
+                <div class="form-row">
+                  <button type="button" class="btn-secondary" data-action="create">创建实例</button>
+                  <button type="button" class="btn-secondary" data-action="start">启动</button>
+                  <button type="button" class="btn-secondary" data-action="stop">停止</button>
+                  <button type="button" class="btn-secondary" data-action="restart">重启</button>
+                </div>
+                <label><input id="qq-instance-auto" type="checkbox" /> 随 Cyrene 启动（需 QQ 渠道已启用）</label>
+                <div class="form-row">
+                  <input id="qq-instance-url" class="form-input form-input--wide" readonly aria-label="SnowLuma WebUI 地址" placeholder="启动就绪后显示 WebUI 链接" />
+                  <button type="button" class="btn-secondary" data-action="open">打开 WebUI</button>
+                </div>
+                <p class="channels-card__hint">创建将下载官方 Windows x64 包。首次凭据保存在实例目录 snowluma/webui-initial-credentials.txt（敏感文件，改密后请删除）；请在官方 WebUI 阅读协议并完成登录。停止 SL 不会关闭 QQ，已加载 Hook 的卸载可在停止前通过 WebUI 操作。</p>
+                <details class="channels-card__hint" id="qq-sl-tutorial">
+                  <summary>使用教程与常见问题（点击展开）</summary>
+                  <ol>
+                    <li>如果 NapCat 已启用，先在下方停用并保存；输入机器人 QQ 号，点击创建实例，等待官方安装包下载和校验完成。下载失败时检查网络或代理。</li>
+                    <li>按需填写需要屏蔽的 QQ 用户或群号，点击“保存黑名单”。用户黑名单同时屏蔽其私聊和群内消息；空黑名单默认放行，群内仍必须 @ 机器人。旧版 SL 白名单不再限制接入。</li>
+                    <li>点击启动。WebUI 端口首次分配后固定复用；完整 WebSocket 地址和 Token 自动写入对应账号配置，无需每次手填。端口被占用时先释放占用，不会自动换地址。</li>
+                    <li>打开 WebUI，首次用户名为 admin，密码在下方实例目录的 snowluma/webui-initial-credentials.txt。按官方提示改密后删除该明文文件；WebUI 登录密码不是 OneBot Token。</li>
+                    <li>在官方 WebUI 阅读并确认协议，手动选择专用 QQ 进程进行 Hook。绑定账号之外的连接会被拒绝。连接建立不代表 QQ Hook 已正常捕获消息。</li>
+                    <li>无回复时检查 QQ 是否登录、Hook、连接状态、黑名单及模型配置；用另一个未被拉黑的 QQ 发消息，不要用机器人给自己发。</li>
+                    <li>停止或真正退出 Cyrene 会停止受管 SL，不会保证卸载已注入的 Hook；需要时先在 WebUI 卸载。自动启动默认关闭。QQ 客户端和外部浏览器不属于受管数据隔离范围。</li>
+                  </ol>
+                </details>
+                <div class="form-row">
+                  <label class="form-label" for="qq-instance-onebot-url">WebSocket 地址（自动配置）</label>
+                  <input id="qq-instance-onebot-url" class="form-input form-input--wide" readonly placeholder="创建后显示，无需手填" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="qq-instance-user-blocklist">QQ 用户黑名单</label>
+                  <textarea id="qq-instance-user-blocklist" class="form-input form-input--wide" rows="2" placeholder="每行一个，屏蔽其私聊和群内消息"></textarea>
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="qq-instance-group-blocklist">群号黑名单</label>
+                  <textarea id="qq-instance-group-blocklist" class="form-input form-input--wide" rows="2" placeholder="每行一个，屏蔽整个群"></textarea>
+                </div>
+                <div class="form-row">
+                  <button type="button" class="btn-secondary" id="qq-instance-save-blocklists">保存黑名单（不重启）</button>
+                </div>
+                <p id="qq-instance-save-feedback" class="channels-card__hint" role="status"></p>
+                <p id="qq-instance-feedback" role="status" style="white-space:pre-wrap;overflow-wrap:anywhere"></p>
+                <div class="form-row">
+                  <label><input id="qq-instance-remove-data" type="checkbox" /> 同时清除 SL 安装、登录及日志数据（保留 Cyrene 对话与记忆）</label>
+                  <button type="button" class="btn-secondary" data-action="delete">删除实例</button>
+                </div>
+              </section>
+            </div>
+          </div>
+
+          <div class="channels-card" id="qq-napcat-card">
             <div class="channels-card__header">
-              <h2>QQ（NapCat / OneBot 11）</h2>
+              <h2>QQ（NapCat）</h2>
               <span class="switch"><input id="channels-qq-enabled" type="checkbox" /><span class="switch__track"><span class="switch__thumb"></span></span></span>
             </div>
             <div class="channels-card__body">
+              <section id="qq-napcat-instance-panel" aria-label="NapCat 账号绑定">
+                <p class="channels-card__hint">NapCat 在外部安装运行，此处管理 Cyrene 的连接与账号绑定。与 SnowLuma 互斥。</p>
+                <div class="form-row">
+                  <label class="form-label" for="qq-napcat-instance-account">机器人 QQ 号</label>
+                  <input id="qq-napcat-instance-account" class="form-input form-input--wide" inputmode="numeric" placeholder="可创建账号绑定；旧非受管接入仍兼容" />
+                </div>
+                <div class="form-row">
+                  <button type="button" class="btn-secondary" data-action="create">创建账号绑定</button>
+                  <button type="button" class="btn-secondary" data-action="start">启动监听</button>
+                  <button type="button" class="btn-secondary" data-action="stop">停止监听</button>
+                  <button type="button" class="btn-secondary" data-action="delete">删除绑定</button>
+                </div>
+                <label><input id="qq-napcat-instance-auto" type="checkbox" /> 随 Cyrene 启动（需 QQ 渠道已启用）</label>
+                <p id="qq-napcat-instance-feedback" role="status" style="white-space:pre-wrap;overflow-wrap:anywhere"></p>
+              </section>
+              <details class="channels-card__hint">
+                <summary>NapCat 使用教程（点击展开）</summary>
+                <ol>
+                  <li>在外部安装并启动 NapCat，登录专用机器人 QQ。若使用账号绑定，先停用渠道，再输入该 QQ 号创建。</li>
+                  <li>设置监听模式、端口及 Token，填写好友/群白名单，启用渠道并保存。空白名单不会回复。</li>
+                  <li>在 NapCat 创建 WebSocket Client，填入下方显示的完整连接 URL 和相同 Token，再启用连接。Token 不是 WebUI 密码。</li>
+                  <li>使用另一个白名单 QQ 私聊测试；群聊需群号白名单并 @ 机器人。切换到 SnowLuma 前先停止并删除绑定。</li>
+                </ol>
+              </details>
+              <fieldset id="qq-napcat-legacy-controls" style="border:0;margin:0;padding:0;min-width:0">
               <div class="channels-status" id="channels-qq-status">
                 <span class="channels-status__dot channels-status__dot--offline"></span>
                 <span class="channels-status__text">未启用</span>
               </div>
+
               <p class="channels-card__hint">
-                Cyrene 在 Windows 监听反向 WebSocket，NapCat 作为 WebSocket Client 连接。
+                Cyrene 监听反向 WebSocket，QQ 后端作为 WebSocket Client 连接。
                 群聊仅响应白名单群中的 @；群聊共享个人记忆但强制禁用工具，请只添加可信群。
               </p>
               <div class="form-row">
@@ -1221,6 +1306,7 @@
                 <button type="button" class="btn-secondary" id="channels-qq-test">测试连接</button>
               </div>
               <div class="channels-feedback" id="channels-qq-feedback"></div>
+              </fieldset>
             </div>
           </div>
 

--- a/src/renderer/settings/settings.ts
+++ b/src/renderer/settings/settings.ts
@@ -222,6 +222,7 @@ if (!window.settings) {
     channelsSaveConfig: () => Promise.resolve({}),
     channelsRestart: () => Promise.resolve({ ok: false }),
     channelsQqTestConnection: () => Promise.resolve({ ok: false, error: "settings api unavailable" }),
+    channelsQqInstance: () => Promise.reject(new Error("settings api unavailable")),
     channelsQqBotTestConnection: () => Promise.resolve({ ok: false, error: "settings api unavailable" }),
     channelsLogGet: () => Promise.resolve([]),
     channelsLogClear: () => Promise.resolve({ ok: true }),

--- a/src/renderer/settings/shared/types.ts
+++ b/src/renderer/settings/shared/types.ts
@@ -297,6 +297,7 @@ export interface SettingsApi {
   channelsSaveConfig: (patch: unknown) => Promise<any>;
   channelsRestart: () => Promise<{ ok: boolean }>;
   channelsQqTestConnection: () => Promise<{ ok: boolean; error?: string; detail?: Record<string, unknown> }>;
+  channelsQqInstance: (request: import("../../../shared/qq-instance").QqInstanceRequest) => Promise<import("../../../shared/qq-instance").QqInstanceStatus>;
   channelsQqBotTestConnection: () => Promise<{ ok: boolean; error?: string; detail?: Record<string, unknown> }>;
   channelsLogGet: (limit?: number) => Promise<unknown[]>;
   channelsLogClear: () => Promise<{ ok: boolean }>;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -415,6 +415,7 @@ export const IPC = {
   CHANNELS_FEISHU_TEST_CONNECTION: "channels:feishu:test-connection",
   CHANNELS_FEISHU_TEST_WEBHOOK_REACHABLE: "channels:feishu:test-webhook-reachable",
   CHANNELS_QQ_TEST_CONNECTION: "channels:qq:test-connection",
+  CHANNELS_QQ_INSTANCE: "channels:qq:instance",
   // QQ 官方机器人（QQ 开放平台）专属
   CHANNELS_QQBOT_TEST_CONNECTION: "channels:qqbot:test-connection",
   // 消息日志

--- a/src/shared/qq-instance.ts
+++ b/src/shared/qq-instance.ts
@@ -1,0 +1,23 @@
+export type QqBackend = "napcat" | "snowluma";
+export interface QqInstance {
+  backend: QqBackend;
+  accountId: string;
+  autoStart: boolean;
+}
+export type QqInstanceAction = "status" | "create" | "start" | "stop" | "restart" | "delete" | "open" | "configure";
+export interface QqInstanceRequest {
+  action: QqInstanceAction;
+  backend?: QqBackend;
+  accountId?: string;
+  autoStart?: boolean;
+  removeData?: boolean;
+}
+export interface QqInstanceStatus {
+  instance: QqInstance | null;
+  phase: "absent" | "installing" | "stopped" | "starting" | "running" | "error";
+  message: string;
+  webuiUrl?: string;
+  onebotUrl?: string;
+  root: string;
+  version?: string;
+}


### PR DESCRIPTION
## 背景与目标

为 QQ 渠道新增 SnowLuma 受管接入，在应用中完成实例创建、安装、启动、停止和重启，并保留原有 NapCat 接入方式。目前只允许一个受管实例绑定一个 QQ 账号，同一时间仅运行一个 QQ 后端。

## 主要改动

- 从 SnowLuma 官方 Release 下载固定的 Windows x64 版本，校验 SHA-256 后安全解压；运行文件、配置、日志与凭据放在应用 userData 下的专属实例目录。
- 增加受管进程守护与退出清理、单账号绑定校验及按账号区分的渠道上下文，拒绝与绑定账号不符的连接和消息。
- 将 SnowLuma 与 NapCat 拆成独立设置卡片，分别展示生命周期操作与访问控制配置。
- SnowLuma WebUI 端口首次分配后持久化，兼容已有端口配置；端口冲突明确报错，不再静默换地址。WebUI 仅监听回环地址。
- 自动写入完整的 OneBot WebSocket 路径及认证配置，避免每次登录后重新填写连接信息；提供 WebUI 链接与本地初始凭据文件入口。
- 在应用内添加默认折叠的使用教程，并新增中文使用与边界说明文档。

## 访问控制与兼容性

- **SnowLuma 使用黑名单**：空黑名单允许私聊进入；群聊仍需提及机器人。用户黑名单同时作用于私聊与群聊，群黑名单屏蔽整个群。
- **NapCat 保持原有白名单语义**，不改变现有用户的访问范围。
- 新实例清空上一实例的访问控制列表，默认不自动启动；保留的数据目录不能直接重新绑定其他账号。
- 渠道历史按账号区分，但个人 Agent 的记忆仍然共享，不将其描述为多租户隔离。

## 验证

- [x] `npx vitest run src/main/channels src/renderer/settings/channels/qq-instance-panel.test.ts`：36 个测试文件、235 项测试通过。
- [x] `npm run build`：完整构建通过；最终运行时改动另通过 `npm run build:main`。
- [x] `node scripts/verify/snowluma-smoke.cjs`：路径、配置、凭据、守护进程退出与重新启动地址稳定性检查通过；使用模拟服务，不加载 QQ。
- [x] 设置页浏览器预览检查：两张独立卡片、黑名单输入与默认折叠教程。
- [x] 提交差异检查；未包含运行数据、凭据、下载包或个人开发启动脚本。
- [ ] 真实 QQ 完整收发与长期运行仍需人工验收；以上测试不代表真实 QQ 端到端验证。

## 已知边界

- 当前自动安装目标为 Windows x64，固定 SnowLuma 1.14.15。
- 停止受管进程不保证卸载已注入现有 QQ 进程的 Hook；未开启自动 Hook 加载，也不会自动接受许可协议。
- 初始 WebUI 凭据保存在实例目录的敏感本地文件中，不写入普通状态信息或日志。
- 应用可约束自身及受管子进程的数据路径，但不保证 Windows、浏览器和外部 QQ 进程没有其他系统级写入。
- PR 不携带 SnowLuma 二进制，也不复制其实现源码；公开分发前仍需复核上游许可证与分发义务。

## 提交拆分

1. `419a28c7`：受管运行时、单账号接入及相关测试。
2. `f37e5302`：独立设置卡片、黑名单、端口持久化与折叠教程相关界面和文档。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 QQ（SnowLuma）受管接入，可在设置页完成安装、创建、启动、停止、重启和删除。
  * 支持 SnowLuma WebUI、自动启动设置及用户/群黑名单配置。
  * QQ（SnowLuma）与 QQ（NapCat）分为独立配置卡片，共用唯一 QQ 接入槽。
  * 受管账号拥有独立会话历史，端口冲突时提供明确错误提示。

* **文档**
  * 新增 SnowLuma 受管接入的安装、配置、使用限制与生命周期说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #96
